### PR TITLE
User, FI heading

### DIFF
--- a/__tests__/UserFiHeading.js
+++ b/__tests__/UserFiHeading.js
@@ -24,31 +24,66 @@ var institution = {
   ]
 }
 
-describe('FiStatus', function(){
+describe('UserFiHeading', function(){
+  describe('render without institution', function() {
 
-  var headingComponent = <UserFiHeading institution={{}} year='2017' user={user} />
+    var headingComponent = <UserFiHeading institution={{}} year='2017' user={user} />
 
-  var heading = TestUtils.renderIntoDocument(headingComponent);
-  var headingNode = ReactDOM.findDOMNode(heading);
+    var heading = TestUtils.renderIntoDocument(headingComponent);
+    var headingNode = ReactDOM.findDOMNode(heading);
 
-  it('renders the component', function(){
-    expect(headingNode).toBeDefined();
+    it('renders the component', function(){
+      expect(headingNode).toBeDefined();
+    });
+
+    it('passes through the institution appropriately as props', function(){
+      expect(heading.props.institution).toEqual({});
+    });
+
+    it('passes through the user appropriately as props', function(){
+      expect(heading.props.user).toEqual(user);
+    });
+
+    it('passes through the year appropriately as props', function(){
+      expect(heading.props.year).toEqual('2017');
+    });
+
+    it('renders correctly', function(){
+      expect(headingNode.textContent).toEqual('Welcome to 2017 HMDA filing, User1');
+    });
   });
 
-  it('passes through the institution appropriately as props', function(){
-    expect(heading.props.institution).toEqual({});
-  });
+  describe('render with institution', function() {
 
-  it('passes through the user appropriately as props', function(){
-    expect(heading.props.user).toEqual(user);
-  });
+    var headingComponent = <UserFiHeading institution={institution} year='2017' user={user} />
 
-  it('passes through the year appropriately as props', function(){
-    expect(heading.props.year).toEqual('2017');
-  });
+    var heading = TestUtils.renderIntoDocument(headingComponent);
+    var headingNode = ReactDOM.findDOMNode(heading);
 
-  it('renders correctly', function(){
-    expect(headingNode.textContent).toEqual('Welcome to 2017 HMDA filing, User1');
-  });
+    it('renders the component', function(){
+      expect(headingNode).toBeDefined();
+    });
 
+    it('passes through the institution appropriately as props', function(){
+      expect(heading.props.institution).toEqual({
+        "name": "Wacky data",
+        "status": 2,
+        "editReports": [
+          {
+            "timestamp": 1457464448191,
+            "edits": {
+              "syntactical": 2,
+              "validity": 1,
+              "quality": 2,
+              "macro": 1
+            }
+          }
+        ]
+      });
+    });
+
+    it('renders correctly', function(){
+      expect(headingNode.textContent).toEqual('User1 filing in 2017 on behalf of Wacky data');
+    });
+  });
 });

--- a/__tests__/UserFiHeading.js
+++ b/__tests__/UserFiHeading.js
@@ -1,0 +1,54 @@
+jest.dontMock('../src/js/UserFiHeading.jsx');
+
+var React = require('react');
+var ReactDOM = require('react-dom');
+var TestUtils = require('react-addons-test-utils');
+
+
+var UserFiHeading = require('../src/js/UserFiHeading.jsx');
+
+var user = 'User1';
+var institution = {
+  "name": "Wacky data",
+  "status": 2,
+  "editReports": [
+    {
+      "timestamp": 1457464448191,
+      "edits": {
+        "syntactical": 2,
+        "validity": 1,
+        "quality": 2,
+        "macro": 1
+      }
+    }
+  ]
+}
+
+describe('FiStatus', function(){
+
+  var headingComponent = <UserFiHeading institution={{}} year='2017' user={user} />
+
+  var heading = TestUtils.renderIntoDocument(headingComponent);
+  var headingNode = ReactDOM.findDOMNode(heading);
+
+  it('renders the component', function(){
+    expect(headingNode).toBeDefined();
+  });
+
+  it('passes through the institution appropriately as props', function(){
+    expect(heading.props.institution).toEqual({});
+  });
+
+  it('passes through the user appropriately as props', function(){
+    expect(heading.props.user).toEqual(user);
+  });
+
+  it('passes through the year appropriately as props', function(){
+    expect(heading.props.year).toEqual('2017');
+  });
+
+  it('renders correctly', function(){
+    expect(headingNode.textContent).toEqual('Welcome to 2017 HMDA filing, User1');
+  });
+
+});

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "dev:html": "cp src/index.html dist/index.html",
     "dev:build": "npm run dev:js && npm run dev:sass && npm run dev:html",
     "postinstall": "npm run clean",
-    "watch:js": "nodemon -e js,jsx -w src/js -x 'npm run dev:js & npm test'",
+    "watch:js": "nodemon -e js,jsx -w src/js -w __tests__ -x 'npm run dev:js & npm test'",
     "watch:sass": "nodemon -e scss -w src/scss -x 'npm run dev:sass'",
     "watch:html": "nodemon -e html -w src -x 'npm run dev:html'",
     "watch": "npm run watch:js & npm run watch:sass & npm run watch:html & npm run browser"

--- a/src/index.html
+++ b/src/index.html
@@ -10,6 +10,7 @@
 
 <body>
   <div id="userSelectRoot"></div>
+  <div id="userFiHeading"></div>
   <div id="app"></div>
   <script src='js/app.min.js'></script>
 </body>

--- a/src/js/UserFiHeading.jsx
+++ b/src/js/UserFiHeading.jsx
@@ -1,12 +1,10 @@
 var React = require('react');
 var UserFiHeading = React.createClass({
   render: function(){
-    var headingText = null;
+    var headingText = 'Welcome to ' + this.props.year + ' HMDA filing, ' + this.props.user;
 
     if (this.props.institution.name) {
       headingText = this.props.user + ' filing in ' + this.props.year + ' on behalf of ' + this.props.institution.name;
-    } else {
-      headingText = 'Welcome to ' + this.props.year + ' HMDA filing, ' + this.props.user;
     }
 
     return <h1>{headingText}</h1>

--- a/src/js/UserFiHeading.jsx
+++ b/src/js/UserFiHeading.jsx
@@ -1,0 +1,16 @@
+var React = require('react');
+var UserFiHeading = React.createClass({
+  render: function(){
+    var headingText = null;
+
+    if (this.props.institution.name) {
+      headingText = this.props.user + ' filing in ' + this.props.year + ' on behalf of ' + this.props.institution.name;
+    } else {
+      headingText = 'Welcome to ' + this.props.year + ' HMDA filing, ' + this.props.user;
+    }
+
+    return <h1>{headingText}</h1>
+  }
+});
+
+module.exports = UserFiHeading;

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -2,6 +2,7 @@ var React = require('react');
 var ReactDOM = require('react-dom');
 var api = require('./api');
 var UserSelect = require('./UserSelect.jsx');
+var UserFiHeading = require('./UserFiHeading.jsx');
 var FiContainer = require('./FiContainer.jsx');
 
 
@@ -21,4 +22,9 @@ function selectCallback(e){
   api.getInstitutions(user, function(institutions){
     container.updateInstitutions(institutions);
   });
+
+  ReactDOM.render(
+    <UserFiHeading institution={{}} year='2017' user={user} />,
+    document.getElementById('userFiHeading')
+  );
 }

--- a/src/scss/app.scss
+++ b/src/scss/app.scss
@@ -2,9 +2,9 @@
   display:none;
 }
 
-#FiContainer {
-  width: 50%;
-  margin-left:25%;
+body {
+  margin: 0 auto;
+  width: 1000px;
 }
 
 .DivisionWrapper {
@@ -31,7 +31,7 @@
 }
 
 .EditReportsWrapper {
-  margin:0; 
+  margin:0;
   padding-left:1.7em;
   margin-top:8px;
 }


### PR DESCRIPTION
Adds a heading to display the user, FI, and year for the filer.

The component is created within `index.js` in the callback for the user selection. I think that's ok, for now, because we don't have another way to get a user.

The year is also hard coded. For the first time we collect files this is also ok, only 1 year (2017) will be collected.

Closes #29 (see for more details)
