### PR TITLE
Edits detail

### DIFF
--- a/__tests__/DivisionHeader.js
+++ b/__tests__/DivisionHeader.js
@@ -10,7 +10,7 @@ var DivisionHeader = require('../src/js/DivisionHeader.jsx');
 
 describe('divisionHeader', function(){
 
-  var headerComponent = <DivisionHeader text="testtext"/>;
+  var headerComponent = <DivisionHeader>testtext</DivisionHeader>;
   var header = TestUtils.renderIntoDocument(headerComponent);
   var headerNode = ReactDOM.findDOMNode(header);
 
@@ -19,7 +19,7 @@ describe('divisionHeader', function(){
   });
 
   it('sets the text prop appropriately', function(){
-    expect(header.props.text).toEqual('testtext');
+    expect(header.props.children).toEqual('testtext');
   });
 
 });

--- a/__tests__/EditsContainer.js
+++ b/__tests__/EditsContainer.js
@@ -1,5 +1,6 @@
 jest.dontMock('../src/js/EditsContainer.jsx');
 jest.dontMock('../src/js/EditsSyntacticalValidity.jsx');
+jest.dontMock('../src/js/EditsHeaderDescription.jsx');
 
 var React = require('react');
 var ReactDOM = require('react-dom');
@@ -103,7 +104,7 @@ describe('EditsContainer', function(){
   });
 
   it('properly renders child elements', function(){
-    expect(TestUtils.scryRenderedDOMComponentsWithTag(container, 'h2').length).toEqual(2);
+    expect(TestUtils.scryRenderedDOMComponentsWithClass(container, 'EditsHeaderDescription').length).toEqual(2);
     expect(TestUtils.scryRenderedDOMComponentsWithTag(container, 'p').length).toEqual(3);
   });
 });

--- a/__tests__/EditsHeaderDescription.js
+++ b/__tests__/EditsHeaderDescription.js
@@ -1,0 +1,27 @@
+jest.dontMock('../src/js/EditsHeaderDescription.jsx');
+
+var React = require('react');
+var ReactDOM = require('react-dom');
+var TestUtils = require('react-addons-test-utils');
+
+var EditsHeaderDescription = require('../src/js/EditsHeaderDescription.jsx');
+
+describe('EditsHeaderDescription', function(){
+
+  var headerComponent = <EditsHeaderDescription>Syntactical</EditsHeaderDescription>;
+  var header = TestUtils.renderIntoDocument(headerComponent);
+  var headerNode = ReactDOM.findDOMNode(header);
+
+  it('renders the header', function(){
+    expect(headerNode).toBeDefined();
+  });
+
+  it('sets the prop appropriately', function(){
+    expect(header.props.children).toEqual('Syntactical');
+  });
+
+  it('correctly sets the desc', function(){
+    expect(header.getDescription('Syntactical')).toEqual('This is the syntactical description.')
+  });
+
+});

--- a/__tests__/EditsSyntacticalValidity.js
+++ b/__tests__/EditsSyntacticalValidity.js
@@ -1,4 +1,5 @@
 jest.dontMock('../src/js/EditsSyntacticalValidity.jsx');
+jest.dontMock('../src/js/EditsSyntacticalValidityDetail.jsx');
 
 var React = require('react');
 var ReactDOM = require('react-dom');
@@ -76,7 +77,7 @@ describe('EditsSyntacticalValidity', function(){
 
   it('properly renders needed child components', function(){
     expect(TestUtils.scryRenderedDOMComponentsWithClass(syntactical, 'EditsSummary').length).toEqual(2);
-    expect(TestUtils.scryRenderedDOMComponentsWithClass(syntactical, 'EditsDetails').length).toEqual(2);
+    expect(TestUtils.scryRenderedDOMComponentsWithClass(syntactical, 'EditsSyntacticalValidityDetail').length).toEqual(2);
   });
 
 });

--- a/__tests__/EditsSyntacticalValidityDetail.js
+++ b/__tests__/EditsSyntacticalValidityDetail.js
@@ -1,0 +1,42 @@
+jest.dontMock('../src/js/EditsSyntacticalValidityDetail.jsx');
+
+var React = require('react');
+var ReactDOM = require('react-dom');
+var TestUtils = require('react-addons-test-utils');
+
+var EditsSyntacticalValidityDetail = require('../src/js/EditsSyntacticalValidityDetail.jsx');
+
+var edits = [
+  {
+    "id": 1,
+    "desc": "Here is a desc",
+    "field": "Year",
+    "valueSubmitted": "1967"
+  }, {
+    "id": 2,
+    "desc": "Here is another desc",
+    "field": "Year",
+    "valueSubmitted": "1800"
+  }
+];
+
+describe('EditsSyntacticalValidity', function(){
+
+  var detailComponent = <EditsSyntacticalValidityDetail edits={edits} />
+  var detail = TestUtils.renderIntoDocument(detailComponent);
+  var detailNode = ReactDOM.findDOMNode(detail);
+
+  it('renders the component', function(){
+    expect(detailNode).toBeDefined();
+  });
+
+  it('passes through the edits appropriately as props', function(){
+    expect(detail.props.edits).toEqual(edits);
+  });
+
+  it('properly renders needed elements', function(){
+    expect(TestUtils.scryRenderedDOMComponentsWithTag(detail, 'table').length).toEqual(1);
+    expect(TestUtils.scryRenderedDOMComponentsWithTag(detail, 'tr').length).toEqual(3);
+    expect(TestUtils.scryRenderedDOMComponentsWithTag(detail, 'td').length).toEqual(8);
+  });
+});

--- a/src/js/DivisionHeader.jsx
+++ b/src/js/DivisionHeader.jsx
@@ -1,5 +1,9 @@
 var React = require('react');
+
 var DivisionHeader = React.createClass({
+  propTypes: {
+    children: React.PropTypes.string.isRequired
+  },
   render: function(){
     return <h2 className="DivisionHeader">{this.props.children}</h2>
   }

--- a/src/js/EditsContainer.jsx
+++ b/src/js/EditsContainer.jsx
@@ -1,5 +1,6 @@
 var React = require('react');
 var EditsSyntacticalValidity = require('./EditsSyntacticalValidity.jsx');
+var EditsHeaderDescription = require('./EditsHeaderDescription.jsx');
 
 var EditsContainer = React.createClass({
   getInitialState: function() {
@@ -108,17 +109,11 @@ var EditsContainer = React.createClass({
           <p>Filing progress will go here. It could be in progress or complete or ...</p>
         </div>
         <div className="two-third">
-          <div>
-            <h2>Syntactical Edits</h2>
-            <p>This is a description of the syntactical edits. It will provide information to filers about the edits they are about to see.</p>
-            <EditsSyntacticalValidity id="syntactical" edits={this.state.edits.syntactical} />
-          </div>
-          <div>
-            <h2>Validity Edits</h2>
-            <p>This is a description of the validity edits. It will provide information to filers about the edits they are about to see.</p>
-            <EditsSyntacticalValidity id="validity" edits={this.state.edits.validity} />
-          </div>
+          <EditsHeaderDescription>Syntactical</EditsHeaderDescription>
+          <EditsSyntacticalValidity id="syntactical" edits={this.state.edits.syntactical} />
 
+          <EditsHeaderDescription>Validity</EditsHeaderDescription>
+          <EditsSyntacticalValidity id="validity" edits={this.state.edits.validity} />
         </div>
       </div>
     )

--- a/src/js/EditsHeaderDescription.jsx
+++ b/src/js/EditsHeaderDescription.jsx
@@ -1,6 +1,9 @@
 var React = require('react');
 
 var EditsHeaderDescription = React.createClass({
+  propTypes: {
+    children: React.PropTypes.string.isRequired
+  },
   getDescription: function(editType) {
     var desc = null;
     switch (editType) {

--- a/src/js/EditsHeaderDescription.jsx
+++ b/src/js/EditsHeaderDescription.jsx
@@ -1,0 +1,35 @@
+var React = require('react');
+
+var EditsHeaderDescription = React.createClass({
+  getDescription: function(editType) {
+    var desc = null;
+    switch (editType) {
+      case 'Syntactical':
+        desc = 'This is the syntactical description.'
+        break;
+      case 'Validity':
+        desc = 'This is the validity description.'
+        break;
+      case 'Quality':
+        desc = 'This is the quality description.'
+        break;
+      case 'Macro':
+        desc = 'This is the macro description.'
+        break;
+      default:
+        throw new Error('Unexpected edit type. Unable to create edit description');
+    }
+
+    return desc
+  },
+  render: function() {
+    return (
+      <div className="EditsHeaderDescription">
+        <h2>{this.props.children} Edits</h2>
+        <p>{this.getDescription(this.props.children)}</p>
+      </div>
+    )
+  }
+});
+
+module.exports = EditsHeaderDescription;

--- a/src/js/EditsSyntacticalValidity.jsx
+++ b/src/js/EditsSyntacticalValidity.jsx
@@ -1,4 +1,5 @@
 var React = require('react');
+var EditsSyntacticalValidityDetail = require('./EditsSyntacticalValidityDetail.jsx');
 
 var EditsSyntacticalValidity = React.createClass({
   propTypes: {
@@ -7,38 +8,15 @@ var EditsSyntacticalValidity = React.createClass({
   render: function() {
     var _this = this;
     return (
-      <div className="EditsSyntacticalValidity full" id={this.props.id}>
-        <div className="tableHeader half">Loan Number</div>
-        <div className="tableHeader half">Edits</div>
+      <div className="EditsSyntacticalValidity full edits" id={this.props.id}>
+        <div className="table-header half">Loan Number</div>
+        <div className="table-header half">Edits</div>
         {this.props.edits.map(function(loan, i) {
           return (
             <div className="EditsSummary" key={i}>
               <div className="half summary">{loan.loanNumber}</div>
               <div className="half summary">{loan.edits.length}</div>
-              <div className="EditsDetails">
-                <table width="100%">
-                  <thead>
-                    <tr>
-                      <th>Edit ID</th>
-                      <th>Description</th>
-                      <th>Field</th>
-                      <th>Submitted Value</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {loan.edits.map(function(edit, i) {
-                      return (
-                        <tr key={edit.id}>
-                          <td>{edit.id}</td>
-                          <td>{edit.desc}</td>
-                          <td>{edit.field}</td>
-                          <td>{edit.valueSubmitted}</td>
-                        </tr>
-                      )
-                    })}
-                  </tbody>
-                </table>
-              </div>
+              <EditsSyntacticalValidityDetail edits={loan.edits} />
             </div>
           )
         })}

--- a/src/js/EditsSyntacticalValidityDetail.jsx
+++ b/src/js/EditsSyntacticalValidityDetail.jsx
@@ -1,0 +1,38 @@
+var React = require('react');
+
+var EditsSyntacticalValidity = React.createClass({
+  propTypes: {
+    edits: React.PropTypes.array
+  },
+  render: function() {
+    var _this = this;
+    return (
+      <div className="EditsSyntacticalValidityDetail edits-detail">
+        <table width="100%">
+          <thead>
+            <tr>
+              <th width="15%">Edit ID</th>
+              <th width="45%">Description</th>
+              <th width="15%">Field</th>
+              <th width="25%">Submitted Value</th>
+            </tr>
+          </thead>
+          <tbody>
+            {this.props.edits.map(function(edit, i) {
+              return (
+                <tr key={edit.id}>
+                  <td>{edit.id}</td>
+                  <td>{edit.desc}</td>
+                  <td>{edit.field}</td>
+                  <td>{edit.valueSubmitted}</td>
+                </tr>
+              )
+            })}
+          </tbody>
+        </table>
+      </div>
+    )
+  }
+});
+
+module.exports = EditsSyntacticalValidity;

--- a/src/less/app.less
+++ b/src/less/app.less
@@ -14,7 +14,7 @@
 @import (less) "components/InstitutionStatus.less";
 @import (less) "components/Resubmit.less";
 @import (less) "components/UploadForm.less";
-@import (less) "components/EditsSyntacticalValidity.less";
+@import (less) "components/Edits.less";
 
 body {
   font-family: "AvenirNextLTW01-Regular";

--- a/src/less/components/Edits.less
+++ b/src/less/components/Edits.less
@@ -1,5 +1,5 @@
-.EditsSyntacticalValidity {
-  .tableHeader {
+.edits {
+  .table-header {
     color: #101820;
     background: #f7f8f9;
     border-bottom: 1px solid @gray-40;
@@ -31,7 +31,7 @@
     border: 1px solid @gray-40;
     margin: 0 0 20px;
   }
-  .EditsDetails {
+  .edits-detail {
     padding: 0 20px;
   }
   .summary {


### PR DESCRIPTION
Depends on #81 
- adds in a detail component for the syntax and validity errors
- changes `EditsSyntacticalValidity.less` to `Edits.less` to make it apparent that its used across all edit components

Closes #78 
