### PR TITLE
Quality edits

### DIFF
--- a/__tests__/EditsContainer.js
+++ b/__tests__/EditsContainer.js
@@ -1,5 +1,5 @@
 jest.dontMock('../src/js/EditsContainer.jsx');
-jest.dontMock('../src/js/EditsSyntacticalValidity.jsx');
+jest.dontMock('../src/js/EditsGrouped.jsx');
 jest.dontMock('../src/js/EditsDetail.jsx');
 jest.dontMock('../src/js/EditsMacro.jsx');
 jest.dontMock('../src/js/EditsHeaderDescription.jsx');

--- a/__tests__/EditsContainer.js
+++ b/__tests__/EditsContainer.js
@@ -38,8 +38,8 @@ describe('EditsContainer', function() {
   });
 
   it('properly renders child elements', function(){
-    expect(TestUtils.scryRenderedDOMComponentsWithClass(container, 'EditsHeaderDescription').length).toEqual(3);
-    expect(TestUtils.scryRenderedDOMComponentsWithTag(container, 'p').length).toEqual(4);
+    expect(TestUtils.scryRenderedDOMComponentsWithClass(container, 'EditsHeaderDescription').length).toEqual(4);
+    expect(TestUtils.scryRenderedDOMComponentsWithTag(container, 'p').length).toEqual(5);
   });
 
   it('calls superagent.get', function() {

--- a/__tests__/EditsGrouped.js
+++ b/__tests__/EditsGrouped.js
@@ -1,11 +1,11 @@
-jest.dontMock('../src/js/EditsSyntacticalValidity.jsx');
+jest.dontMock('../src/js/EditsGrouped.jsx');
 jest.dontMock('../src/js/EditsDetail.jsx');
 
 var React = require('react');
 var ReactDOM = require('react-dom');
 var TestUtils = require('react-addons-test-utils');
 
-var EditsSyntacticalValidity = require('../src/js/EditsSyntacticalValidity.jsx');
+var EditsGrouped = require('../src/js/EditsGrouped.jsx');
 
 var edits = {
   "syntactical": [
@@ -57,9 +57,9 @@ var edits = {
   ]
 }
 
-describe('EditsSyntacticalValidity', function(){
+describe('EditsGrouped', function(){
 
-  var syntacticalComponent = <EditsSyntacticalValidity id="syntactical" edits={edits.syntactical} />
+  var syntacticalComponent = <EditsGrouped id="syntactical" edits={edits.syntactical} />
   var syntactical = TestUtils.renderIntoDocument(syntacticalComponent);
   var syntacticalNode = ReactDOM.findDOMNode(syntactical);
 

--- a/src/js/EditsContainer.jsx
+++ b/src/js/EditsContainer.jsx
@@ -11,6 +11,7 @@ var EditsContainer = React.createClass({
       edits: {
         syntactical: [],
         validity: [],
+        quality: [],
         macro: {}
       }
     }
@@ -41,6 +42,9 @@ var EditsContainer = React.createClass({
 
           <EditsHeaderDescription>Validity</EditsHeaderDescription>
           <EditsGrouped id="validity" edits={this.state.edits.validity} />
+
+          <EditsHeaderDescription>Quality</EditsHeaderDescription>
+          <EditsGrouped id="quality" edits={this.state.edits.quality} />
 
           <EditsHeaderDescription>Macro</EditsHeaderDescription>
           <EditsMacro id="macro" edits={this.state.edits.macro} />

--- a/src/js/EditsContainer.jsx
+++ b/src/js/EditsContainer.jsx
@@ -1,7 +1,7 @@
 var React = require('react');
 var request = require('superagent');
 
-var EditsSyntacticalValidity = require('./EditsSyntacticalValidity.jsx');
+var EditsGrouped = require('./EditsGrouped.jsx');
 var EditsMacro = require('./EditsMacro.jsx');
 var EditsHeaderDescription = require('./EditsHeaderDescription.jsx');
 
@@ -37,10 +37,10 @@ var EditsContainer = React.createClass({
         </div>
         <div className="two-third">
           <EditsHeaderDescription>Syntactical</EditsHeaderDescription>
-          <EditsSyntacticalValidity id="syntactical" edits={this.state.edits.syntactical} />
+          <EditsGrouped id="syntactical" edits={this.state.edits.syntactical} />
 
           <EditsHeaderDescription>Validity</EditsHeaderDescription>
-          <EditsSyntacticalValidity id="validity" edits={this.state.edits.validity} />
+          <EditsGrouped id="validity" edits={this.state.edits.validity} />
 
           <EditsHeaderDescription>Macro</EditsHeaderDescription>
           <EditsMacro id="macro" edits={this.state.edits.macro} />

--- a/src/js/EditsGrouped.jsx
+++ b/src/js/EditsGrouped.jsx
@@ -1,13 +1,13 @@
 var React = require('react');
 var EditsDetail = require('./EditsDetail.jsx');
 
-var EditsSyntacticalValidity = React.createClass({
+var EditsGrouped = React.createClass({
   propTypes: {
     edits: React.PropTypes.array
   },
   render: function() {
     return (
-      <div className="EditsSyntacticalValidity full edits" id={this.props.id}>
+      <div className="EditsGrouped full edits" id={this.props.id}>
         <div className="table-header half">Loan Number</div>
         <div className="table-header half">Edits</div>
         {this.props.edits.map(function(loan, i) {
@@ -24,4 +24,4 @@ var EditsSyntacticalValidity = React.createClass({
   }
 });
 
-module.exports = EditsSyntacticalValidity;
+module.exports = EditsGrouped;

--- a/src/js/data/edits.json
+++ b/src/js/data/edits.json
@@ -78,6 +78,35 @@
         ]
       }
     ],
+    "quality": [
+      {
+        "loanNumber": "1337",
+        "edits": [
+          {
+            "id": 1,
+            "desc": "Here is a quality desc",
+            "field": "Argle",
+            "valueSubmitted": "Bargle",
+            "justification": "",
+            "verified": false
+          }, {
+            "id": 2,
+            "desc": "Another quality desc",
+            "field": "Year",
+            "valueSubmitted": "1800",
+            "justification": "A good year",
+            "verified": true
+          }, {
+            "id": 3,
+            "desc": "Third quality desc",
+            "field": "Year",
+            "valueSubmitted": "1609",
+            "justification": "",
+            "verified": false
+          }
+        ]
+      }
+    ],
     "macro": {
       "edits": [
         {


### PR DESCRIPTION
Adds quality edits (to the data and the `EditContainer`

Reuses the `SyntacticalValidity` component which has been renamed `EditsGrouped` to reflect that it is used across different edit types to represent grouped by some value (currently loan number, but should we want to allow this to be changed on the fly, we could easily pass a configuring object in its props)
