### PR TITLE
Remove text area for Quality edits

### DIFF
--- a/__tests__/EditsDetail.js
+++ b/__tests__/EditsDetail.js
@@ -47,7 +47,7 @@ describe('EditsDetail', function(){
     expect(TestUtils.scryRenderedDOMComponentsWithTag(macroDetail, 'table').length).toEqual(1);
     expect(TestUtils.scryRenderedDOMComponentsWithTag(macroDetail, 'tr').length).toEqual(3);
     expect(TestUtils.scryRenderedDOMComponentsWithTag(macroDetail, 'td').length).toEqual(6);
-    expect(TestUtils.scryRenderedDOMComponentsWithTag(macroDetail, 'textarea').length).toEqual(2);
+    expect(TestUtils.scryRenderedDOMComponentsWithTag(macroDetail, 'textarea').length).toEqual(1);
     expect(TestUtils.scryRenderedDOMComponentsWithClass(macroDetail, 'expandable_content').length).toEqual(1);
   });
 });

--- a/__tests__/EditsDetailRow.js
+++ b/__tests__/EditsDetailRow.js
@@ -12,12 +12,14 @@ var larDetail = {
 
 var macroDetail= {
   edit: 'm1',
-  verification: ''
+  verification: '',
+  verified: false
 };
 
 var macroDetailVerified = {
   edit: 'm1',
-  verification: 'Verified'
+  verification: 'Verified',
+  verified: true
 };
 var WrapperTable = React.createClass({
   render: function() {
@@ -75,4 +77,3 @@ describe('EditsDetailRow', function(){
     expect(TestUtils.scryRenderedDOMComponentsWithTag(mr3, 'textarea').length).toEqual(0);
   });
 });
-

--- a/server/json/macro.json
+++ b/server/json/macro.json
@@ -3,10 +3,12 @@
   "edits": [
     {
       "edit": "m1",
-      "verification": ""
+      "verification": "asdf",
+      "verified": true
     }, {
       "edit": "m2",
-      "verification": ""
+      "verification": "",
+      "verified": false
     }
   ]
 }

--- a/server/json/quality.json
+++ b/server/json/quality.json
@@ -6,15 +6,15 @@
       "lars": [
         {
           "lar": {"loanId": "q1"},
-          "verification": ""
+          "verified": true
         },
         {
           "lar": {"loanId": "q2"},
-          "verification": ""
+          "verified": false
         },
         {
           "lar": {"loanId": "q3"},
-          "verification": ""
+          "verified": false
         }
       ]
     }

--- a/src/js/EditsDetail.jsx
+++ b/src/js/EditsDetail.jsx
@@ -22,7 +22,6 @@ var EditsDetail = React.createClass({
 
     var headers = Object.keys(this.props.details[0]);
     if(!headers) return null;
-    if(headers.indexOf('verification') !== -1) headers.push('verified');
 
     var primary = self.props.primary;
     var setAppStatus = self.props.setAppStatus;

--- a/src/js/EditsDetailRow.jsx
+++ b/src/js/EditsDetailRow.jsx
@@ -13,7 +13,7 @@ var EditsDetailRow = React.createClass({
   componentWillMount: function(){
     this.setState({
       verification: this.props.detail.verification,
-      verified: !!this.props.detail.verification
+      verified: this.props.detail.verified
     });
   },
 
@@ -28,18 +28,20 @@ var EditsDetailRow = React.createClass({
     }
 
     if(field === 'lar') return detail[field].loanId;
-    
+
+    if(field === 'verified') return this.makeCheck()
+
     return detail[field];
   },
 
   makeCheck: function(){
-    if(this.state.verification !== undefined){
-      return <td><input type="checkbox" onChange={this.toggleText} checked={this.state.verified}/></td>
+    if(this.state.verified !== undefined){
+      return <input type="checkbox" onChange={this.toggleText} checked={this.state.verified}/>
     }
   },
 
   toggleText: function(e){
-    if(!this.state.verification){
+    if(this.state.verification === ''){
       return e.preventDefault();
     }
 
@@ -65,7 +67,6 @@ var EditsDetailRow = React.createClass({
         return <td key={i}>{self.makeTdContent(detail, field)}</td>
       }
       )}
-      {self.makeCheck()}
     </tr>
   }
 });

--- a/src/js/EditsDetailRow.jsx
+++ b/src/js/EditsDetailRow.jsx
@@ -19,10 +19,16 @@ var EditsDetailRow = React.createClass({
 
   makeTdContent: function(detail, field){
     if(field === 'verification'){
-      if(this.state.verified) return this.state.verification;
-      else return <textarea onChange={this.updateText} value={this.state.verification}/>
+      if(this.state.verified) {
+        return this.state.verification;
+      }
+      else {
+        return <textarea onChange={this.updateText} value={this.state.verification}/>
+      }
     }
+
     if(field === 'lar') return detail[field].loanId;
+    
     return detail[field];
   },
 


### PR DESCRIPTION
Closes #145 
- simplify rendering by modifying json (more to come out of backend API work)
- renders quality with only the checkbox
  - leaving text area for macro, along with the checkbox
