### PR TITLE
Verify all

### DIFF
--- a/__tests__/EditsDetail.js
+++ b/__tests__/EditsDetail.js
@@ -11,6 +11,7 @@ var EditsDetail = require('../src/js/EditsDetail.jsx');
 
 var syntacticalObj = JSON.parse(fs.readFileSync('./server/json/syntactical.json'));
 var macroObj = JSON.parse(fs.readFileSync('./server/json/macro.json'));
+var qualityObj = JSON.parse(fs.readFileSync('./server/json/quality.json'));
 
 describe('EditsDetail', function(){
 
@@ -49,5 +50,24 @@ describe('EditsDetail', function(){
     expect(TestUtils.scryRenderedDOMComponentsWithTag(macroDetail, 'td').length).toEqual(6);
     expect(TestUtils.scryRenderedDOMComponentsWithTag(macroDetail, 'textarea').length).toEqual(1);
     expect(TestUtils.scryRenderedDOMComponentsWithClass(macroDetail, 'expandable_content').length).toEqual(1);
+  });
+
+  var qualityDetail = TestUtils.renderIntoDocument(<EditsDetail details={qualityObj.edits[0].lars} type="quality"/>);
+  var qualityNode = ReactDOM.findDOMNode(qualityDetail);
+
+  it('renders the component', function(){
+    expect(qualityNode).toBeDefined();
+  });
+
+  it('passes through the edits appropriately as props', function(){
+    expect(qualityDetail.props.details).toEqual(qualityObj.edits[0].lars);
+  });
+
+  it('passes through the type', function(){
+    expect(qualityDetail.props.type).toEqual('quality');
+  });
+
+  it('renders all the checkboxes, including check all', function(){
+    expect(TestUtils.scryRenderedDOMComponentsWithTag(qualityDetail, 'input').length).toEqual(4);
   });
 });

--- a/__tests__/EditsDetail.js
+++ b/__tests__/EditsDetail.js
@@ -47,7 +47,7 @@ describe('EditsDetail', function(){
     expect(TestUtils.scryRenderedDOMComponentsWithTag(macroDetail, 'table').length).toEqual(1);
     expect(TestUtils.scryRenderedDOMComponentsWithTag(macroDetail, 'tr').length).toEqual(3);
     expect(TestUtils.scryRenderedDOMComponentsWithTag(macroDetail, 'td').length).toEqual(6);
-    expect(TestUtils.scryRenderedDOMComponentsWithTag(macroDetail, 'textarea').length).toEqual(2);
+    expect(TestUtils.scryRenderedDOMComponentsWithTag(macroDetail, 'textarea').length).toEqual(1);
     expect(TestUtils.scryRenderedDOMComponentsWithClass(macroDetail, 'expandable_content').length).toEqual(1);
   });
 });

--- a/__tests__/EditsDetail.js
+++ b/__tests__/EditsDetail.js
@@ -68,6 +68,6 @@ describe('EditsDetail', function(){
   });
 
   it('renders all the checkboxes, including check all', function(){
-    expect(TestUtils.scryRenderedDOMComponentsWithTag(qualityDetail, 'input').length).toEqual(4);
+    expect(TestUtils.scryRenderedDOMComponentsWithTag(qualityDetail, 'input').length).toEqual(1);
   });
 });

--- a/__tests__/EditsDetailRow.js
+++ b/__tests__/EditsDetailRow.js
@@ -12,12 +12,14 @@ var larDetail = {
 
 var macroDetail= {
   edit: 'm1',
-  verification: ''
+  verification: '',
+  verified: false
 };
 
 var macroDetailVerified = {
   edit: 'm1',
-  verification: 'Verified'
+  verification: 'Verified',
+  verified: true
 };
 var WrapperTable = React.createClass({
   render: function() {
@@ -75,4 +77,3 @@ describe('EditsDetailRow', function(){
     expect(TestUtils.scryRenderedDOMComponentsWithTag(mr3, 'textarea').length).toEqual(0);
   });
 });
-

--- a/__tests__/EditsDetailRow.js
+++ b/__tests__/EditsDetailRow.js
@@ -52,7 +52,7 @@ describe('EditsDetailRow', function(){
   });
 
   it('renders macro elements', function(){
-    expect(TestUtils.scryRenderedDOMComponentsWithTag(macroRow, 'td').length).toEqual(3);
+    expect(TestUtils.scryRenderedDOMComponentsWithTag(macroRow, 'td').length).toEqual(4);
     expect(TestUtils.scryRenderedDOMComponentsWithTag(macroRow, 'textarea').length).toEqual(1);
   });
 
@@ -63,7 +63,7 @@ describe('EditsDetailRow', function(){
   )
 
   it('updates when the textarea is updated', function(){
-    expect(TestUtils.scryRenderedDOMComponentsWithTag(mr2, 'td').length).toEqual(3);
+    expect(TestUtils.scryRenderedDOMComponentsWithTag(mr2, 'td').length).toEqual(4);
     expect(TestUtils.scryRenderedDOMComponentsWithTag(mr2, 'textarea')[0].value).toEqual('updated');
   });
 
@@ -73,7 +73,7 @@ describe('EditsDetailRow', function(){
   )
 
   it('updates when the checkbox is clicked', function(){
-    expect(TestUtils.scryRenderedDOMComponentsWithTag(mr3, 'td').length).toEqual(3);
+    expect(TestUtils.scryRenderedDOMComponentsWithTag(mr3, 'td').length).toEqual(4);
     expect(TestUtils.scryRenderedDOMComponentsWithTag(mr3, 'textarea').length).toEqual(0);
   });
 });

--- a/server/json/macro.json
+++ b/server/json/macro.json
@@ -3,12 +3,10 @@
   "edits": [
     {
       "edit": "m1",
-      "verification": "asdf",
-      "verified": true
+      "verification": "asdf"
     }, {
       "edit": "m2",
-      "verification": "",
-      "verified": false
+      "verification": ""
     }
   ]
 }

--- a/server/json/macro.json
+++ b/server/json/macro.json
@@ -3,10 +3,12 @@
   "edits": [
     {
       "edit": "m1",
-      "verification": ""
+      "verification": "asdf",
+      "verified": true
     }, {
       "edit": "m2",
-      "verification": ""
+      "verification": "",
+      "verified": false
     }
   ]
 }

--- a/server/json/quality.json
+++ b/server/json/quality.json
@@ -6,15 +6,15 @@
       "lars": [
         {
           "lar": {"loanId": "q1"},
-          "verification": ""
+          "verified": true
         },
         {
           "lar": {"loanId": "q2"},
-          "verification": ""
+          "verified": false
         },
         {
           "lar": {"loanId": "q3"},
-          "verification": ""
+          "verified": false
         }
       ]
     }

--- a/server/json/quality.json
+++ b/server/json/quality.json
@@ -3,18 +3,28 @@
   "edits": [
     {
       "edit": "quality1337",
+      "verified": true,
       "lars": [
         {
-          "lar": {"loanId": "q1"},
-          "verified": true
+          "lar": {"loanId": "q1"}
         },
         {
-          "lar": {"loanId": "q2"},
-          "verified": false
+          "lar": {"loanId": "q2"}
         },
         {
-          "lar": {"loanId": "q3"},
-          "verified": false
+          "lar": {"loanId": "q3"}
+        }
+      ]
+    },
+    {
+      "edit": "quality1338",
+      "verified": false,
+      "lars": [
+        {
+          "lar": {"loanId": "q4"}
+        },
+        {
+          "lar": {"loanId": "q5"}
         }
       ]
     }

--- a/src/js/EditsContainer.jsx
+++ b/src/js/EditsContainer.jsx
@@ -117,13 +117,13 @@ var EditsContainer = React.createClass({
     return (
       <div className="EditsContainerBody">
         <EditsHeaderDescription>Syntactical Edits</EditsHeaderDescription>
-        <EditsGrouped group={this.state.syntactical.edits} groupByRow={this.state.groupByRow} setAppStatus={this.props.setAppStatus}/>
+        <EditsGrouped group={this.state.syntactical.edits} groupByRow={this.state.groupByRow} setAppStatus={this.props.setAppStatus} type="syntactical"/>
 
         <EditsHeaderDescription>Validity Edits</EditsHeaderDescription>
-        <EditsGrouped group={this.state.validity.edits} groupByRow={this.state.groupByRow} setAppStatus={this.props.setAppStatus}/>
+        <EditsGrouped group={this.state.validity.edits} groupByRow={this.state.groupByRow} setAppStatus={this.props.setAppStatus} type="validity"/>
 
         <EditsHeaderDescription>Quality Edits</EditsHeaderDescription>
-        <EditsGrouped group={this.state.quality.edits} groupByRow={this.state.groupByRow} setAppStatus={this.props.setAppStatus}/>
+        <EditsGrouped group={this.state.quality.edits} groupByRow={this.state.groupByRow} setAppStatus={this.props.setAppStatus} type="quality"/>
 
         <EditsHeaderDescription>Macro Edits</EditsHeaderDescription>
         <EditsMacro group={this.state.macro.edits} setAppStatus={this.props.setAppStatus}/>

--- a/src/js/EditsDetail.jsx
+++ b/src/js/EditsDetail.jsx
@@ -21,7 +21,7 @@ var EditsDetail = React.createClass({
     if(this.props.type === 'quality') {
       return (
         <tr>
-          <td colSpan="2">
+          <td>
             <input type="checkbox" value="Verify all {this.props.primary} quality" /> I certify to the accuracy of all data fields referenced by the {this.props.primary} quality edits.
           </td>
         </tr>
@@ -35,6 +35,7 @@ var EditsDetail = React.createClass({
 
     var headers = Object.keys(this.props.details[0]);
     if(!headers) return null;
+    if(headers.indexOf('verification') !== -1) headers.push('verified');
 
     var primary = self.props.primary;
     var setAppStatus = self.props.setAppStatus;

--- a/src/js/EditsDetail.jsx
+++ b/src/js/EditsDetail.jsx
@@ -22,7 +22,6 @@ var EditsDetail = React.createClass({
 
     var headers = Object.keys(this.props.details[0]);
     if(!headers) return null;
-    if(headers.indexOf('verification') !== -1) headers.push('verified');
 
     var primary = self.props.primary;
     var setAppStatus = self.props.setAppStatus;

--- a/src/js/EditsDetail.jsx
+++ b/src/js/EditsDetail.jsx
@@ -5,7 +5,8 @@ var EditsDetail = React.createClass({
   propTypes: {
     details: React.PropTypes.array,
     primary: React.PropTypes.string,
-    setAppStatus: React.PropTypes.func
+    setAppStatus: React.PropTypes.func,
+    type: React.PropTypes.string
   },
 
   headerMap: {
@@ -14,6 +15,18 @@ var EditsDetail = React.createClass({
     type: 'Edit Type',
     verification: 'Verification',
     verified: 'Verified'
+  },
+
+  renderCheckAll: function() {
+    if(this.props.type === 'quality') {
+      return (
+        <tr>
+          <td colSpan="2">
+            <input type="checkbox" value="Verify all {this.props.primary} quality" /> I certify to the accuracy of all data fields referenced by the {this.props.primary} quality edits.
+          </td>
+        </tr>
+      )
+    }
   },
 
   render: function() {
@@ -40,8 +53,10 @@ var EditsDetail = React.createClass({
             {this.props.details.map(function(detail, i){
               return <EditsDetailRow id={i} key={i} primary={primary} detail={detail} setAppStatus={setAppStatus}/>
             })}
+            {self.renderCheckAll()}
           </tbody>
         </table>
+
       </div>
     )
   }

--- a/src/js/EditsDetailRow.jsx
+++ b/src/js/EditsDetailRow.jsx
@@ -13,7 +13,7 @@ var EditsDetailRow = React.createClass({
   componentWillMount: function(){
     this.setState({
       verification: this.props.detail.verification,
-      verified: this.props.detail.verified
+      verified: this.props.detail.verified || !!this.props.detail.verification
     });
   },
 
@@ -29,19 +29,17 @@ var EditsDetailRow = React.createClass({
 
     if(field === 'lar') return detail[field].loanId;
 
-    if(field === 'verified') return this.makeCheck()
-
     return detail[field];
   },
 
   makeCheck: function(){
-    if(this.state.verified !== undefined){
-      return <input type="checkbox" onChange={this.toggleText} checked={this.state.verified}/>
+    if(this.state.verification !== undefined){
+      return <td><input type="checkbox" onChange={this.toggleText} checked={this.state.verified}/></td>
     }
   },
 
   toggleText: function(e){
-    if(this.state.verification === ''){
+    if(!this.state.verification){
       return e.preventDefault();
     }
 
@@ -67,6 +65,7 @@ var EditsDetailRow = React.createClass({
         return <td key={i}>{self.makeTdContent(detail, field)}</td>
       }
       )}
+      {self.makeCheck()}
     </tr>
   }
 });

--- a/src/js/EditsDetailRow.jsx
+++ b/src/js/EditsDetailRow.jsx
@@ -13,7 +13,7 @@ var EditsDetailRow = React.createClass({
   componentWillMount: function(){
     this.setState({
       verification: this.props.detail.verification,
-      verified: !!this.props.detail.verification
+      verified: this.props.detail.verified
     });
   },
 
@@ -28,18 +28,20 @@ var EditsDetailRow = React.createClass({
     }
 
     if(field === 'lar') return detail[field].loanId;
-    
+
+    if(field === 'verified') return this.makeCheck()
+
     return detail[field];
   },
 
   makeCheck: function(){
-    if(this.state.verification !== undefined){
-      return <td><input type="checkbox" onChange={this.toggleText} checked={this.state.verified}/></td>
+    if(this.state.verified !== undefined){
+      return <input type="checkbox" onChange={this.toggleText} checked={this.state.verified}/>
     }
   },
 
   toggleText: function(e){
-    if(!this.state.verification){
+    if(this.state.verification === ''){
       return e.preventDefault();
     }
 
@@ -65,7 +67,6 @@ var EditsDetailRow = React.createClass({
         return <td key={i}>{self.makeTdContent(detail, field)}</td>
       }
       )}
-      {self.makeCheck()}
     </tr>
   }
 });

--- a/src/js/EditsDetailRow.jsx
+++ b/src/js/EditsDetailRow.jsx
@@ -19,10 +19,16 @@ var EditsDetailRow = React.createClass({
 
   makeTdContent: function(detail, field){
     if(field === 'verification'){
-      if(this.state.verified) return this.state.verification;
-      else return <textarea onChange={this.updateText} value={this.state.verification}/>
+      if(this.state.verified) {
+        return this.state.verification;
+      }
+      else {
+        return <textarea onChange={this.updateText} value={this.state.verification}/>
+      }
     }
+
     if(field === 'lar') return detail[field].loanId;
+    
     return detail[field];
   },
 

--- a/src/js/EditsGrouped.jsx
+++ b/src/js/EditsGrouped.jsx
@@ -5,7 +5,8 @@ var EditsGrouped = React.createClass({
   propTypes: {
     group: React.PropTypes.array,
     groupByRow: React.PropTypes.bool,
-    setAppStatus: React.PropTypes.func
+    setAppStatus: React.PropTypes.func,
+    type: React.PropTypes.string
   },
 
   getPrimary: function(groupObj){
@@ -51,7 +52,7 @@ var EditsGrouped = React.createClass({
                   </span>
                 </span>
               </button>
-              <EditsDetail primary={primary} details={self.getSecondary(groupObj)} setAppStatus={self.props.setAppStatus}/>
+              <EditsDetail primary={primary} details={self.getSecondary(groupObj)} setAppStatus={self.props.setAppStatus} type={self.props.type}/>
             </div>
           )
         })}


### PR DESCRIPTION
**Needs #153 merged first**

Closes #146 
- adds in the **single** verify all for each quality check
- passes the `type` of edit as a prop so that it can render only for quality edits
- currently no interaction (no API calls) on the checkbox
  - will wait for https://github.com/cfpb/hmda-platform/pull/422

Also created #157 to simplify some of this.
