### PR TITLE
Create HDMA_API_PORT scheme for seamlessness between dev, compose, and deploy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,13 +11,14 @@ RUN apt-get update && \
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 COPY . /usr/src/app
+COPY nginx/nginx.conf /etc/nginx/nginx.conf
 
 RUN npm cache clean && \
     npm install && \
     npm run clean && \
-    npm run build
-
-COPY nginx/nginx.conf /etc/nginx/nginx.conf
+    npm run build && \
+    sed -i.bak s/{{HMDA_API_PORT}}/${HMDA_API_PORT:-8080}/ /etc/nginx/nginx.conf && \
+    rm /etc/nginx/nginx.conf.bak
 
 EXPOSE 80
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 FROM nginx:1.10
 MAINTAINER Wyatt Pearsall<Wyatt.Pearsall@cfpb.gov>
 
+ARG HMDA_API_PORT=8080
+
 RUN apt-get update && \
     apt-get install -y curl && \
     apt-get install -y make && \
@@ -17,8 +19,9 @@ RUN npm cache clean && \
     npm install && \
     npm run clean && \
     npm run build && \
-    sed -i.bak s/{{HMDA_API_PORT}}/${HMDA_API_PORT:-8080}/ /etc/nginx/nginx.conf && \
-    rm /etc/nginx/nginx.conf.bak
+    sed -i.bak s/{{HMDA_API_PORT}}/${HMDA_API_PORT}/ /etc/nginx/nginx.conf && \
+    rm /etc/nginx/nginx.conf.bak && \
+    echo "api port set to ${HMDA_API_PORT}"
 
 EXPOSE 80
 

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -10,7 +10,7 @@ http {
   include  mime.types;
 
   upstream api{
-    server api:10003;
+    server api:{{HMDA_API_PORT}};
   }
 
   server {


### PR DESCRIPTION
If the envvar `HMDA_API_PORT` is set, that will be the upstream port, otherwise it will be 8080. This can be set on dev machines if desired and in jenkins on build
