### PR TITLE
Add descriptions for edits

### DIFF
--- a/__tests__/EditsHeaderDescription.js
+++ b/__tests__/EditsHeaderDescription.js
@@ -21,7 +21,16 @@ describe('EditsHeaderDescription', function(){
   })
 
   it('correctly sets the desc', function(){
-    expect(headerNode.textContent).toEqual('Syntactical EditsThis is the syntactical description.')
+    expect(headerNode.textContent).toEqual('Syntactical EditsEdits that check whether the loan/application register is in the correct format and whether the data covers the correct filing year. The loan/application register cannot be filed until the filer corrects all syntactical edit errors and reuploads the updated loan/application register to the HMDA Platform.')
+  })
+
+  const headerLAR = TestUtils.renderIntoDocument(
+    <Wrapper><EditsHeaderDescription>lar</EditsHeaderDescription></Wrapper>
+  )
+  const headerLARNode = ReactDOM.findDOMNode(headerLAR)
+
+  it('correctly sets the desc', function(){
+    expect(headerLARNode.textContent).toEqual('Loan Application RecordsLAR refers to the loan/application register. Loan/Application Register means both the record of information required to be collected pursuant to § 1003.4 and the record submitted annually or quarterly, as applicable, pursuant to § 1003.5(a).')
   })
 
 })

--- a/src/js/components/EditsHeaderDescription.jsx
+++ b/src/js/components/EditsHeaderDescription.jsx
@@ -23,7 +23,7 @@ const getText = (editType) => {
       break
     case 'macro':
       title =  'Macro Edits'
-      desc = 'This is the macro description.'
+      desc = 'Edits that check whether the submitted loan/application register as a whole conforms to expected values. The loan/application register cannot be filed until the filer either confirms the accuracy of all the values flagged by the macro quality edits in the HMDA Platform or corrects the flagged values and reuploads the updated loan/application register to the HMDA Platform.'
       break
     default:
       throw new Error('Unexpected edit type. Unable to create edit description')

--- a/src/js/components/EditsHeaderDescription.jsx
+++ b/src/js/components/EditsHeaderDescription.jsx
@@ -11,7 +11,7 @@ const getText = (editType) => {
       break
     case 'syntactical':
       title = 'Syntactical Edits'
-      desc = 'This is the syntactical description.'
+      desc = 'Edits that check whether the loan/application register is in the correct format and whether the data covers the correct filing year. The loan/application register cannot be filed until the filer corrects all syntactical edit errors and reuploads the updated loan/application register to the HMDA Platform.'
       break
     case 'validity':
       title =  'Validity Edits'

--- a/src/js/components/EditsHeaderDescription.jsx
+++ b/src/js/components/EditsHeaderDescription.jsx
@@ -7,7 +7,7 @@ const getText = (editType) => {
   switch (editType) {
     case 'lar':
       title = 'Loan Application Records'
-      desc = 'This is the LAR description'
+      desc = 'LAR refers to the loan/application register. Loan/Application Register means both the record of information required to be collected pursuant to § 1003.4 and the record submitted annually or quarterly, as applicable, pursuant to § 1003.5(a).'
       break
     case 'syntactical':
       title = 'Syntactical Edits'

--- a/src/js/components/EditsHeaderDescription.jsx
+++ b/src/js/components/EditsHeaderDescription.jsx
@@ -15,7 +15,7 @@ const getText = (editType) => {
       break
     case 'validity':
       title =  'Validity Edits'
-      desc = 'This is the validity description.'
+      desc = 'Edits that check whether there are valid values in each data field. The loan/application register cannot be filed until the filer corrects all validity edit errors and reuploads the updated loan/application register to the HMDA Platform.'
       break
     case 'quality':
       title =  'Quality Edits'

--- a/src/js/components/EditsHeaderDescription.jsx
+++ b/src/js/components/EditsHeaderDescription.jsx
@@ -19,7 +19,7 @@ const getText = (editType) => {
       break
     case 'quality':
       title =  'Quality Edits'
-      desc = 'This is the quality description.'
+      desc = 'Edits that check whether entries in the individual data fields or combinations of data fields conform to expected values. The loan/application register cannot be filed until the filer either confirms the accuracy of all values flagged by quality edits in the HMDA Platform, or corrects the flagged values and reuploads the updated loan/application register to the HMDA Platform.'
       break
     case 'macro':
       title =  'Macro Edits'


### PR DESCRIPTION
Closes #235. Closes #239.
- adds in better descriptions for the edit headers
- updates tests
