### PR TITLE
Update progress and rendering of submission components

### DIFF
--- a/__tests__/RefileWarning.js
+++ b/__tests__/RefileWarning.js
@@ -40,7 +40,7 @@ describe('Refile Warning', () => {
       </Wrapper>
     )
 
-    expect(TestUtils.findRenderedDOMComponentWithClass(refileWarning, 'refile-text').innerHTML.match(refileText)[0]).toEqual(refileText);
+    expect(TestUtils.findRenderedDOMComponentWithClass(refileWarning, 'usa-alert-heading').innerHTML.match(refileText)[0]).toEqual(refileText);
     expect(TestUtils.scryRenderedDOMComponentsWithTag(refileWarning, 'a').length).toEqual(1);
   });
 
@@ -59,7 +59,7 @@ describe('Refile Warning', () => {
       </Wrapper>
     )
 
-    expect(TestUtils.findRenderedDOMComponentWithClass(refileWarning, 'refile-text').innerHTML.match(validateText)[0]).toEqual(validateText);
+    expect(TestUtils.findRenderedDOMComponentWithClass(refileWarning, 'usa-alert-heading').innerHTML.match(validateText)[0]).toEqual(validateText);
     expect(TestUtils.scryRenderedDOMComponentsWithTag(refileWarning, 'a').length).toEqual(0);
   });
 
@@ -77,7 +77,7 @@ describe('Refile Warning', () => {
       </Wrapper>
     )
 
-    expect(TestUtils.scryRenderedDOMComponentsWithClass(refileWarning, 'refile-text').length).toEqual(0);
+    expect(TestUtils.scryRenderedDOMComponentsWithClass(refileWarning, 'usa-alert-heading').length).toEqual(0);
     expect(TestUtils.scryRenderedDOMComponentsWithTag(refileWarning, 'a').length).toEqual(0);
   });
 

--- a/__tests__/Signature.js
+++ b/__tests__/Signature.js
@@ -9,7 +9,7 @@ import TestUtils from 'react-addons-test-utils'
 const fs = require('fs')
 const signJSON = JSON.parse(fs.readFileSync('./server/json/receipt.json'))
 const status = {
-  code: 12,
+  code: 11,
   message: ''
 }
 
@@ -52,7 +52,7 @@ describe('Signature component', () => {
   })
 
   const statusSigned = {
-    code: 13,
+    code: 12,
     message: ''
   }
   const signatureSigned = TestUtils.renderIntoDocument(

--- a/src/js/actions/index.js
+++ b/src/js/actions/index.js
@@ -91,7 +91,7 @@ export function receiveSubmission(data) {
   } else if (typeof(data.id) === 'object') {
     latestSubmissionId = data.id.sequenceNumber
   }
-  
+
   return {
     type: types.RECEIVE_SUBMISSION,
     ...data
@@ -383,7 +383,7 @@ export function pollForProgress() {
     return getLatestSubmission()
       .then(json => dispatch(receiveSubmission(json)))
       .then(json => {
-        if(json.status.code < 8){
+        if(json.status.code < 8 && json.status.code !== 5){
           setTimeout(() => poller(dispatch), 500)
         }
       })

--- a/src/js/components/IRSReport.jsx
+++ b/src/js/components/IRSReport.jsx
@@ -8,9 +8,23 @@ const showConfirmation = (code) => {
   )
 }
 
+const showWarning = (props) => {
+  if(props.status.code > 9) return null
+
+  return (
+    <div className="usa-alert usa-alert-warning">
+      <div className="usa-alert-body">
+        <h3 className="usa-alert-heading">You can not verify the IRS report until all edits have been verified and the report has been generated.</h3>
+      </div>
+    </div>
+  )
+}
+
 const IRSReport = (props) => {
   if (!props.msas) return null
   const isChecked = props.status.code > 10 ? true : false
+  const isDisabled = props.status.code > 9 ? false : true
+
   return (
     <div className="IRSReport">
       <h2>Institution Register Summary</h2>
@@ -51,6 +65,9 @@ const IRSReport = (props) => {
           })}
         </tbody>
       </table>
+
+      {showWarning(props)}
+
       <ul className="usa-unstyled-list">
         <li>
           <input id="irs-verify"
@@ -58,10 +75,12 @@ const IRSReport = (props) => {
             type="checkbox"
             value="irs-verify"
             onChange={e => props.onIRSClick(e.target.checked)}
-            checked={isChecked} />
+            checked={isChecked}
+            disabled={isDisabled} />
           <label htmlFor="irs-verify">I have verified that all of the submitted data is correct and agree with the accuracy of the values listed.</label>
         </li>
       </ul>
+
       {showConfirmation(props.status.code)}
     </div>
   )

--- a/src/js/components/RefileWarning.jsx
+++ b/src/js/components/RefileWarning.jsx
@@ -1,6 +1,7 @@
 import React, { PropTypes } from 'react'
 import { Link } from 'react-router'
 
+const parserText = 'Parsing error require file resubmission.'
 const refileText = 'Syntactical and validity edits require file resubmission.'
 const validateText = 'Quality and macro edits must be validated before continuing.'
 
@@ -8,15 +9,21 @@ const getText = (props) => {
   let textToRender = null
   let refileLink = null
 
-  if(props.types.syntactical.edits.length !== 0 ||
-     props.types.validity.edits.length !== 0){
-       textToRender = refileText
-       refileLink = getRefileLink(props)
-     }else{
-       textToRender = validateText
-     }
+  if(props.types.hasOwnProperty("syntactical")) {
+    if(props.types.syntactical.edits.length !== 0 || props.types.validity.edits.length !== 0) {
+      textToRender = refileText
+      refileLink = getRefileLink(props)
+    } else {
+      textToRender = validateText
+    }
+  }
 
-  return <h3><span className="cf-icon cf-icon-error cf-icon__3x"></span><span className="refile-text">{textToRender}{refileLink?' ':''}{refileLink}</span></h3>
+  if(props.submission.status.code === 5) {
+    textToRender = parserText
+    refileLink = getRefileLink(props)
+  }
+
+  return <h3 className="usa-alert-heading">{textToRender}{refileLink?' ':''}{refileLink}</h3>
 }
 
 const getRefileLink = (props) => {
@@ -24,12 +31,19 @@ const getRefileLink = (props) => {
 }
 
 const RefileWarning = (props) => {
-  if(!props.types.syntactical) return null
+  //if(!props.types.syntactical) return null
   if (props.submission.status.code > 8) return null
 
+  let alertClass = 'usa-alert-error'
+  if(props.types.hasOwnProperty("syntactical")) {
+    if(props.types.syntactical.edits.length === 0 && props.types.validity.edits.length === 0) {
+      alertClass = 'usa-alert-warning'
+    }
+  }
+
   return (
-    <div className="RefileWarning">
-      <div>
+    <div className={`RefileWarning usa-alert ${alertClass}`}>
+      <div className="usa-alert-body">
         {getText(props)}
       </div>
     </div>

--- a/src/js/components/Signature.jsx
+++ b/src/js/components/Signature.jsx
@@ -12,10 +12,25 @@ const showReceipt = (props) => {
   )
 }
 
+const showWarning = (props) => {
+  if(props.status.code > 10) return null
+
+  return (
+    <div className="usa-alert usa-alert-warning">
+      <div className="usa-alert-body">
+        <h3 className="usa-alert-heading">You can not sign your submission until the IRS report has been verified.</h3>
+      </div>
+    </div>
+  )
+}
+
 const Signature = (props) => {
   const isChecked = props.status.code > 12 ? true : false
+  const isDisabled = props.status.code > 11 ? false : true
+
   return (
     <div className="Signature">
+      {showWarning(props)}
       <ul className="usa-unstyled-list">
         <li>
           <input id="signature"
@@ -23,7 +38,8 @@ const Signature = (props) => {
             type="checkbox"
             value="signature"
             onChange={e => props.onSignatureClick(e.target.checked)}
-            checked={isChecked} />
+            checked={isChecked}
+            disabled={isDisabled} />
           <label htmlFor="signature">I am an authorized representative of my institution with knowledge of the data submitted and can certify to the accuracy and completeness of the data submitted.</label>
         </li>
       </ul>

--- a/src/js/components/Signature.jsx
+++ b/src/js/components/Signature.jsx
@@ -31,6 +31,7 @@ const Signature = (props) => {
   return (
     <div className="Signature">
       {showWarning(props)}
+
       <ul className="usa-unstyled-list">
         <li>
           <input id="signature"

--- a/src/js/components/Signature.jsx
+++ b/src/js/components/Signature.jsx
@@ -2,7 +2,7 @@ import React, { Component, PropTypes } from 'react'
 import { connect } from 'react-redux'
 
 const showReceipt = (props) => {
-  if(props.status.code < 13) return null;
+  if(props.status.code !== 12) return null;
 
   return (
     <div>
@@ -25,8 +25,8 @@ const showWarning = (props) => {
 }
 
 const Signature = (props) => {
-  const isChecked = props.status.code > 12 ? true : false
-  const isDisabled = props.status.code > 11 ? false : true
+  const isChecked = props.status.code === 12 ? true : false
+  const isDisabled = props.status.code > 10 ? false : true
 
   return (
     <div className="Signature">

--- a/src/js/components/ValidationProgress.jsx
+++ b/src/js/components/ValidationProgress.jsx
@@ -3,15 +3,15 @@ import React, { PropTypes } from 'react'
 const ValidationProgress = (props) => {
   const code = props.status.code
 
-  let uploadComplete = null
+  let uploadComplete = 'Uploading...'
   let parsingStatus = null
   let validationStatus = null
 
   if(code > 2) uploadComplete = 'Upload complete'
   if(code > 3) parsingStatus = 'Parsing started...'
   if(code > 4) parsingStatus = 'Parsing complete'
-  if(code > 5) validationStatus = 'Validation started...'
-  if(code > 6) validationStatus = 'Validation complete'
+  if(code > 6) validationStatus = 'Validation started...'
+  if(code > 7) validationStatus = 'Validation complete'
 
   return (
     <ul className="ValidationProgress usa-unstyled-list">

--- a/src/js/containers/Submission.jsx
+++ b/src/js/containers/Submission.jsx
@@ -50,7 +50,7 @@ class SubmissionContainer extends Component {
     // render refileWarning for parsing and validation error status
     if (code === 5 || code === 8) refileWarning = <RefileWarning />
 
-    if (code > 7 && code !== 5) {
+    if (code > 7) {
       editsContainer = <Edits/>
       irs =  <IRSReport />
       sign = <Signature />

--- a/src/js/containers/Submission.jsx
+++ b/src/js/containers/Submission.jsx
@@ -45,7 +45,7 @@ class SubmissionContainer extends Component {
       )
     }
 
-    if (code > 2) progress = <ValidationProgress/>
+    if (code > 1) progress = <ValidationProgress/>
 
     if (code > 7) {
       editsContainer = <Edits/>

--- a/src/js/containers/Submission.jsx
+++ b/src/js/containers/Submission.jsx
@@ -47,9 +47,11 @@ class SubmissionContainer extends Component {
 
     if (code > 1) progress = <ValidationProgress/>
 
+    // render refileWarning for parsing and validation error status
+    if (code === 5 || code === 8) refileWarning = <RefileWarning />
+
     if (code > 7 && code !== 5) {
       editsContainer = <Edits/>
-      refileWarning = <RefileWarning />
       irs =  <IRSReport />
       sign = <Signature />
       summary = <Summary />

--- a/src/js/containers/Submission.jsx
+++ b/src/js/containers/Submission.jsx
@@ -47,7 +47,7 @@ class SubmissionContainer extends Component {
 
     if (code > 1) progress = <ValidationProgress/>
 
-    if (code > 7) {
+    if (code > 7 && code !== 5) {
       editsContainer = <Edits/>
       refileWarning = <RefileWarning />
       irs =  <IRSReport />

--- a/src/js/containers/ValidationProgress.jsx
+++ b/src/js/containers/ValidationProgress.jsx
@@ -6,7 +6,7 @@ function mapStateToProps(state) {
     status
   } = state.app.submission || {
     status: {
-      code: 3,
+      code: 2,
       message: ''
     }
   }


### PR DESCRIPTION
Closes #245 and Closes #246 
- render the progress messages correctly based on status
- don't show some components (edit, irs, signature, summary) if parsing fails
- show warning message for parsing failure
- _a little extra_ ... disable inputs and show warnings for IRS and signature if status isn't ready for them to be used
