### PR TITLE
render 'transmittal sheet' if ts:true

### DIFF
--- a/__tests__/EditsByType.js
+++ b/__tests__/EditsByType.js
@@ -15,7 +15,7 @@ const types = {
   syntactical: JSON.parse(fs.readFileSync('./server/json/syntactical.json')),
   validity: JSON.parse(fs.readFileSync('./server/json/validity.json')),
   quality: JSON.parse(fs.readFileSync('./server/json/quality.json')),
-  macro: JSON.parse(fs.readFileSync('./server/json/macro.json'))
+  macro: {"edits": []}
 }
 
 const typesNoMacro = {
@@ -36,7 +36,7 @@ describe('EditsByType', function() {
   it('properly renders child elements', function(){
     expect(TestUtils.scryRenderedDOMComponentsWithClass(editsByType, 'EditsContainerEntry').length).toEqual(4)
     expect(TestUtils.scryRenderedDOMComponentsWithClass(editsByType, 'EditsHeaderDescription').length).toEqual(4)
-    expect(TestUtils.scryRenderedDOMComponentsWithTag(editsByType, 'table').length).toEqual(7)
+    expect(TestUtils.scryRenderedDOMComponentsWithTag(editsByType, 'table').length).toEqual(6)
   })
 
   const editsByTypeNoMacro = TestUtils.renderIntoDocument(<Wrapper><EditsByType types={typesNoMacro}/></Wrapper>)

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     ],
     "unmockedModulePathPatterns": [
       "<rootDir>/node_modules/react",
+      "<rootDir>/node_modules/lodash",
       "<rootDir>/node_modules/react-dom",
       "<rootDir>/node_modules/react-addons-test-utils",
       "<rootDir>/node_modules/redux-mock-store",

--- a/src/js/actions/index.js
+++ b/src/js/actions/index.js
@@ -329,7 +329,7 @@ export function requestUpload(file) {
     })
 
     xhr.open('POST', getUploadUrl(latestSubmissionId));
-    xhr.setRequestHeader('Accept', 'text/plain');
+    xhr.setRequestHeader('Accept', 'application/json');
     xhr.setRequestHeader('CFPB-HMDA-Institutions', '0');
     xhr.setRequestHeader('CFPB-HMDA-Username', 'fakeuser');
     xhr.setRequestHeader("cache-control", "no-cache");

--- a/src/js/components/EditsByType.jsx
+++ b/src/js/components/EditsByType.jsx
@@ -10,7 +10,7 @@ const renderTables = (editObj, type) => {
   }
 
   if(edits[0] && !edits[0].lars){
-    return <EditsTable data={edits} type={type} label={edits.edit} />
+    return <EditsTable data={edits} type={type} />
   }
 
   return edits.map((edit, i) => {

--- a/src/js/components/EditsByType.jsx
+++ b/src/js/components/EditsByType.jsx
@@ -2,19 +2,21 @@ import React from 'react'
 import EditsHeaderDescription from './EditsHeaderDescription.jsx'
 import EditsTable from '../containers/EditsTable.jsx'
 
-const renderTables = (editObj) => {
+const renderTables = (editObj, type) => {
   const edits = editObj.edits
 
   if(edits.length === 0) {
     return <h4>No edits found</h4>
   }
 
-  if(edits[0] && !edits[0].lars){
-    return <EditsTable data={edits} type={editObj.type}/>
-  }
+  /*if(edits[0] && !edits[0].lars){
+    console.log('EditsByType - renderTables')
+    console.log('lars check')
+    return <EditsTable data={edits} type={type} label={edits.edit} />
+  }*/
 
   return edits.map((edit, i) => {
-    return <EditsTable data={edit.lars} type={editObj.type} label={edit.edit} key={i}/>
+    return <EditsTable lars={edit.lars} ts={edit.ts} type={type} label={edit.edit} key={i}/>
   })
 }
 
@@ -27,7 +29,7 @@ const EditsByType = (props) => {
             <div className="EditsContainerEntry" key={i}>
               <EditsHeaderDescription count={props.types[type].edits.length} type={type} />
               {
-                renderTables(props.types[type])
+                renderTables(props.types[type], type)
               }
             </div>
           )

--- a/src/js/components/EditsByType.jsx
+++ b/src/js/components/EditsByType.jsx
@@ -9,11 +9,9 @@ const renderTables = (editObj, type) => {
     return <h4>No edits found</h4>
   }
 
-  /*if(edits[0] && !edits[0].lars){
-    console.log('EditsByType - renderTables')
-    console.log('lars check')
+  if(edits[0] && !edits[0].lars){
     return <EditsTable data={edits} type={type} label={edits.edit} />
-  }*/
+  }
 
   return edits.map((edit, i) => {
     return <EditsTable lars={edit.lars} ts={edit.ts} type={type} label={edit.edit} key={i}/>

--- a/src/js/containers/EditsTable.jsx
+++ b/src/js/containers/EditsTable.jsx
@@ -6,8 +6,8 @@ const rowForEachLarTypes = ['syntactical', 'validity', 'quality']
 
 const rowForEachLar = (val) => rowForEachLarTypes.indexOf(val) !== -1
 
-const renderHeader = (props) => {
-  let row = props.data[0]
+/*const renderHeader = (props) => {
+  let row = props.lars[0]
   if (rowForEachLar(props.type)) row = row.lar
 
   return (
@@ -19,10 +19,20 @@ const renderHeader = (props) => {
       }
     </tr>
   )
+}*/
+
+const renderTS = (ts) => {
+  if (ts) {
+    return (
+      <tr>
+        <td>Transmittal Sheet</td>
+      </tr>
+    )
+  }
 }
 
 const renderBody = (props) => {
-  return props.data.map((row, i) => {
+  return props.lars.map((row, i) => {
     if(row.lar) row = row.lar
     return <EditsTableRow row={row} key={i}/>
   })
@@ -34,9 +44,11 @@ const EditsTable = (props) => {
       <table width="100%">
         <caption><h3>{props.label ? props.label : null}</h3></caption>
         <thead>
-          {renderHeader(props)}
+          {/*renderHeader(props)*/}
+          <tr><th>Row ID</th></tr>
         </thead>
         <tbody>
+          {renderTS(props.ts)}
           {renderBody(props)}
         </tbody>
       </table>


### PR DESCRIPTION
Closes #250 and Closes #259 

- renders a row with "Transmittal Sheet" instead of loan id if `"ts": true`
- pass `type` to `renderTables` in `EditsByType`, we don't have `type` as a property of within a given edit type in the response
- accepts JSON response from file upload
