### PR TITLE
Institutions

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,10 +88,11 @@
   "dependencies": {
     "babel-polyfill": "6.9.1",
     "babelify": "7.2.0",
-    "immutable": "3.8.1",
     "envify": "3.4.1",
+    "immutable": "3.8.1",
     "jquery": "3.1.0",
     "jquery.easing": "1.4.1",
+    "moment": "2.17.0",
     "oidc-client": "1.2.0",
     "react": "15.3.0",
     "react-dom": "15.3.0",

--- a/src/js/components/Institutions.jsx
+++ b/src/js/components/Institutions.jsx
@@ -3,25 +3,24 @@ import { Link } from 'react-router'
 import UserHeading from '../components/UserHeading.jsx'
 import moment from 'moment'
 
-const renderLabel = (status) => {
-  let bgColor = 'bg-color-red'
-  if(status.code === 2) {
-    color = ''
+const renderTiming = (status, start, end) => {
+  // default to code 1, not-started
+  let messageClass = 'text-secondary'
+  let timing = null
+
+  switch(status.code) {
+    // in-progress
+    case 2:
+      messageClass = 'text-primary'
+      timing = moment(start).fromNow()
+    // completed
+    case 3:
+      messageClass = 'text-green'
+      timing = moment(end).format('MMMM Do')
+    // code 4 is cancelled, do nothing ... defaults are fine
   }
-  if(status.code === 3) {
-    bgColor = 'bg-color-green'
-  }
-  return <span className={`usa-label ${bgColor}`}>{status.message}</span>
-}
 
-const renderTiming = (start, end) => {
-  let timing = <p className="text-gray usa-text-small text-uppercase"><strong className="text-primary">Started</strong> {moment(start).fromNow()}</p>
-
-  if(start === 0) timing = <p className="text-gray usa-text-small text-uppercase"><strong className="text-secondary">Not started</strong></p>
-
-  if(end !== 0) timing = <p className="text-gray usa-text-small text-uppercase"><strong className="text-green">Completed</strong> {moment(end).format('MMMM Do')}</p>
-
-  return timing
+  return <p className="text-gray usa-text-small text-uppercase"><strong className={messageClass}>{status.message}</strong> {timing}</p>
 }
 
 const renderStatus = (code, institutionName, institutionId, period) => {
@@ -29,9 +28,9 @@ const renderStatus = (code, institutionName, institutionId, period) => {
 
   switch(code) {
     case 2:
-      status = <p>{institutionName}'s file is being processed. You can <Link to={`/${institutionId}/${period}`}>view the progress</Link> now.</p>
+      status = <p>{institutionName}'s filing is being processed. You can <Link to={`/${institutionId}/${period}`}>view the progress</Link> now.</p>
     case 3:
-      status = <p>{institutionName}'s file has been processed. You can <Link to={`/${institutionId}/${period}`}>review edits and sign</Link> {institutionName}'s submission now.</p>
+      status = <p>{institutionName}'s filing has been processed. You can <Link to={`/${institutionId}/${period}`}>review edits and sign</Link> {institutionName}'s submission now.</p>
     case 4:
       status = <p>{institutionName}'s filing is complete and signed. You can <Link to={`/${institutionId}/${period}`}>review</Link> {institutionName}'s signed submission now.</p>
   }
@@ -53,9 +52,8 @@ export default class Institution extends Component {
           ).map((filing, i) => {
             return (
             <div key={i}>
-              {renderTiming(filing.start, filing.end)}
+              {renderTiming(filing.status, filing.start, filing.end)}
               <h2>{institution.name}</h2>
-              {/*{renderLabel(filing.status)}*/}
               {renderStatus(filing.status.code, institution.name, filing.institutionId, filing.period)}
             </div>
             )

--- a/src/js/components/Institutions.jsx
+++ b/src/js/components/Institutions.jsx
@@ -1,29 +1,62 @@
 import React, { Component, PropTypes } from 'react'
 import { Link } from 'react-router'
 import UserHeading from '../components/UserHeading.jsx'
+import moment from 'moment'
+
+const renderLabel = (status) => {
+  let bgColor = 'bg-color-red'
+  if(status.code === 2) {
+    color = ''
+  }
+  if(status.code === 3) {
+    bgColor = 'bg-color-green'
+  }
+  return <span className={`usa-label ${bgColor}`}>{status.message}</span>
+}
+
+const renderTiming = (start, end) => {
+  let timing = <p className="text-gray usa-text-small text-uppercase"><strong className="text-primary">Started</strong> {moment(start).fromNow()}</p>
+
+  if(start === 0) timing = <p className="text-gray usa-text-small text-uppercase"><strong className="text-secondary">Not started</strong></p>
+
+  if(end !== 0) timing = <p className="text-gray usa-text-small text-uppercase"><strong className="text-green">Completed</strong> {moment(end).format('MMMM Do')}</p>
+
+  return timing
+}
+
+const renderStatus = (code, institutionName, institutionId, period) => {
+  let status = <p>{institutionName} hasn't started a filing yet. You can <Link to={`/${institutionId}/${period}`}>begin filing</Link> now.</p>
+
+  switch(code) {
+    case 2:
+      status = <p>{institutionName}'s file is being processed. You can <Link to={`/${institutionId}/${period}`}>view the progress</Link> now.</p>
+    case 3:
+      status = <p>{institutionName}'s file has been processed. You can <Link to={`/${institutionId}/${period}`}>review edits and sign</Link> {institutionName}'s submission now.</p>
+    case 4:
+      status = <p>{institutionName}'s filing is complete and signed. You can <Link to={`/${institutionId}/${period}`}>review</Link> {institutionName}'s signed submission now.</p>
+  }
+
+  return status
+}
 
 export default class Institution extends Component {
-
   render() {
-    console.log('institution component')
-    console.log(this.props)
     var self = this
     return (
-    <div className="Institution">
+    <div className="Institutions">
       <UserHeading period="2017" userName={this.props.user.profile.name} />
       {this.props.institutions.map((institution, i) => {
         return (
-        <div key={i}>
-          <h3>{institution.name}</h3>
+        <div key={i} className="institution">
           {self.props.filings.filter(
             filing => filing.institutionId === institution.id
           ).map((filing, i) => {
             return (
             <div key={i}>
-              <p>id: {filing.period}</p>
-              <p>institutionId: {filing.institutionId}</p>
-              <p>status: {filing.status.message}</p>
-              <p><Link to={`/${filing.institutionId}/${filing.period}`}>View filing</Link></p>
+              {renderTiming(filing.start, filing.end)}
+              <h2>{institution.name}</h2>
+              {/*{renderLabel(filing.status)}*/}
+              {renderStatus(filing.status.code, institution.name, filing.institutionId, filing.period)}
             </div>
             )
           })}

--- a/src/js/components/Institutions.jsx
+++ b/src/js/components/Institutions.jsx
@@ -13,6 +13,7 @@ const renderTiming = (status, start, end) => {
     case 1:
       messageClass = 'text-secondary'
       timing = null
+      break
     // in-progress
     case 2:
       messageClass = 'text-primary'

--- a/src/js/components/Institutions.jsx
+++ b/src/js/components/Institutions.jsx
@@ -5,62 +5,121 @@ import moment from 'moment'
 
 const renderTiming = (status, start, end) => {
   // default to code 1, not-started
-  let messageClass = 'text-secondary'
-  let timing = null
+  let messageClass
+  let timing
 
   switch(status.code) {
+    // not-started
+    case 1:
+      messageClass = 'text-secondary'
+      timing = null
     // in-progress
     case 2:
       messageClass = 'text-primary'
       timing = moment(start).fromNow()
+      break
     // completed
     case 3:
       messageClass = 'text-green'
       timing = moment(end).format('MMMM Do')
+      break
     // code 4 is cancelled, do nothing ... defaults are fine
+    default:
+      messageClass = 'text-secondary'
+      timing = null
   }
 
-  return <p className="text-gray usa-text-small text-uppercase"><strong className={messageClass}>{status.message}</strong> {timing}</p>
+  return <p className="text-gray usa-text-small"><strong className={`${messageClass} text-uppercase`}>{status.message}</strong> {timing}</p>
 }
 
 const renderStatus = (code, institutionName, institutionId, period) => {
-  let status = <p>{institutionName} hasn't started a filing yet. You can <Link to={`/${institutionId}/${period}`}>begin filing</Link> now.</p>
+  let status
 
   switch(code) {
+    // not started
+    case 1:
+      status = <p className="status">{institutionName} hasn't started a filing yet. You can <Link to={`/${institutionId}/${period}`}>begin filing</Link> now.</p>
+      break
+    // in progress
     case 2:
-      status = <p>{institutionName}'s filing is being processed. You can <Link to={`/${institutionId}/${period}`}>view the progress</Link> now.</p>
+      status = <p className="status">{institutionName}'s filing is being processed. You can <Link to={`/${institutionId}/${period}`}>view the progress</Link>.</p>
+      break
+    // completed
     case 3:
-      status = <p>{institutionName}'s filing has been processed. You can <Link to={`/${institutionId}/${period}`}>review edits and sign</Link> {institutionName}'s submission now.</p>
+      status = <p className="status">{institutionName}'s filing is complete and signed. You can <Link to={`/${institutionId}/${period}`}>review</Link> {institutionName}'s signed submission.</p>
+      break
+      // cancelled
     case 4:
-      status = <p>{institutionName}'s filing is complete and signed. You can <Link to={`/${institutionId}/${period}`}>review</Link> {institutionName}'s signed submission now.</p>
+      status = <p className="status">{institutionName}'s latest filing has been cancelled. You can <Link to={`/${institutionId}/${period}`}>review</Link> {institutionName}'s cancelled submission or <Link to={`/${institutionId}/${period}`}>submit a new file</Link>.</p>
+      break
+    default:
+      status = <p className="status">{institutionName} hasn't started a filing yet. You can <Link to={`/${institutionId}/${period}`}>begin filing</Link> now.</p>
   }
 
   return status
+}
+
+const renderButton = (code, institutionId, period) => {
+  let buttonText
+
+  switch(code) {
+    // not-started
+    case 1:
+      buttonText = 'File now'
+      break
+    // in progress
+    case 2:
+      buttonText = 'View filing'
+      break
+    // completed
+    case 3:
+      buttonText = 'View filing'
+      break
+    // cancelled
+    case 4:
+      buttonText = 'File now'
+      break
+  }
+
+  return <Link className="usa-button" to={`/${institutionId}/${period}`}>{buttonText}</Link>
 }
 
 export default class Institution extends Component {
   render() {
     var self = this
     return (
-    <div className="Institutions">
+    <div className="Institutions usa-grid-full">
       <UserHeading period="2017" userName={this.props.user.profile.name} />
-      {this.props.institutions.map((institution, i) => {
-        return (
-        <div key={i} className="institution">
-          {self.props.filings.filter(
-            filing => filing.institutionId === institution.id
-          ).map((filing, i) => {
-            return (
-            <div key={i}>
-              {renderTiming(filing.status, filing.start, filing.end)}
-              <h2>{institution.name}</h2>
-              {renderStatus(filing.status.code, institution.name, filing.institutionId, filing.period)}
-            </div>
-            )
-          })}
-        </div>
-        )
-      })}
+      <div className="usa-width-two-thirds">
+        {this.props.institutions.map((institution, i) => {
+          return (
+          <div key={i} className="institution">
+            {self.props.filings.filter(
+              filing => filing.institutionId === institution.id
+            ).map((filing, i) => {
+              return (
+              <div className="usa-grid-full" key={i}>
+                <div className="usa-width-two-thirds">
+                  <h2>{institution.name}</h2>
+                  {renderTiming(filing.status, filing.start, filing.end)}
+                  {renderStatus(filing.status.code, institution.name, filing.institutionId, filing.period)}
+                </div>
+                <div className="usa-width-one-third padding-left-2">
+                  {renderButton(filing.status.code, filing.institutionId, filing.period)}
+                  <Link className="usa-button usa-button-secondary usa-text-small" to={`/${filing.institutionId}/${filing.period}`}>Refile</Link>
+                </div>
+              </div>
+              )
+            })}
+          </div>
+          )
+        })}
+      </div>
+      <div className="usa-width-one-third padding-left-1 padding-right-1 bg-color-gray-lightest">
+        <p>We can use this area as some help text and talk about the process or whatever else we need to mention.</p>
+        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi nec auctor nisl. Nam ut justo nec ligula aliquam pretium et at orci. Nulla pulvinar feugiat tellus, in sagittis sem sollicitudin at. Nunc nec libero at elit consectetur elementum eu at nisl.</p>
+        <p>Curabitur molestie felis massa, vel semper nulla maximus nec. Quisque feugiat nulla nec urna tristique varius. Ut vulputate felis mi, non elementum lacus tempor ut. Etiam tempus porta arcu non venenatis. Vivamus nec tellus eleifend, pulvinar sapien sed, posuere leo.</p>
+      </div>
     </div>
     )
   }

--- a/src/js/components/Institutions.jsx
+++ b/src/js/components/Institutions.jsx
@@ -38,25 +38,25 @@ const renderStatus = (code, institutionName, institutionId, period) => {
   switch(code) {
     // not started
     case 1:
-      status = <p className="status">{institutionName} hasn't started a filing yet. You can <Link to={`/${institutionId}/${period}`}>begin filing</Link> now.</p>
+      status = `${institutionName} hasn't started a filing yet. You can begin filing now.`
       break
     // in progress
     case 2:
-      status = <p className="status">{institutionName}'s filing is being processed. You can <Link to={`/${institutionId}/${period}`}>view the progress</Link>.</p>
+      status = `${institutionName}'s filing is being processed. You can view the progress.`
       break
     // completed
     case 3:
-      status = <p className="status">{institutionName}'s filing is complete and signed. You can <Link to={`/${institutionId}/${period}`}>review</Link> {institutionName}'s signed submission.</p>
+      status = `${institutionName}'s filing is complete and signed. You can review ${institutionName}'s signed submission.`
       break
       // cancelled
     case 4:
-      status = <p className="status">{institutionName}'s latest filing has been cancelled. You can <Link to={`/${institutionId}/${period}`}>review</Link> {institutionName}'s cancelled submission or <Link to={`/${institutionId}/${period}`}>submit a new file</Link>.</p>
+      status = `${institutionName}'s latest filing has been cancelled. You can review ${institutionName}'s cancelled submission or submit a new file.`
       break
     default:
-      status = <p className="status">{institutionName} hasn't started a filing yet. You can <Link to={`/${institutionId}/${period}`}>begin filing</Link> now.</p>
+      status = `${institutionName} hasn't started a filing yet. You can begin filing now.`
   }
 
-  return status
+  return <p className="status">{status}</p>
 }
 
 const renderButton = (code, institutionId, period) => {

--- a/src/js/components/Institutions.jsx
+++ b/src/js/components/Institutions.jsx
@@ -100,7 +100,7 @@ export default class Institution extends Component {
             ).map((filing, i) => {
               return (
               <div className="usa-grid-full" key={i}>
-                <h2>{institution.name} - <span className="text-gray">{institution.id}</span></h2>
+                <h2>{institution.name} - {institution.id}</h2>
                 {renderTiming(filing.status, filing.start, filing.end)}
                 {renderStatus(filing.status.code, institution.name, filing.institutionId, filing.period)}
                 {renderButton(filing.status.code, filing.institutionId, filing.period)}

--- a/src/js/components/Institutions.jsx
+++ b/src/js/components/Institutions.jsx
@@ -85,6 +85,11 @@ const renderButton = (code, institutionId, period) => {
   return <Link className="usa-button" to={`/${institutionId}/${period}`}>{buttonText}</Link>
 }
 
+const renderRefile = (code, institutionId, period) => {
+  if(code === 1) return null
+  return <Link className="usa-button usa-button-secondary usa-text-small" to={`/${institutionId}/${period}`}>Refile</Link>
+}
+
 export default class Institution extends Component {
   render() {
     var self = this
@@ -104,7 +109,7 @@ export default class Institution extends Component {
                 {renderTiming(filing.status, filing.start, filing.end)}
                 {renderStatus(filing.status.code, institution.name, filing.institutionId, filing.period)}
                 {renderButton(filing.status.code, filing.institutionId, filing.period)}
-                <Link className="usa-button usa-button-secondary usa-text-small" to={`/${filing.institutionId}/${filing.period}`}>Refile</Link>
+                {renderRefile(filing.status.code, filing.institutionId, filing.period)}
               </div>
               )
             })}

--- a/src/js/components/Institutions.jsx
+++ b/src/js/components/Institutions.jsx
@@ -39,22 +39,22 @@ const renderStatus = (code, institutionName, institutionId, period) => {
   switch(code) {
     // not started
     case 1:
-      status = `${institutionName} hasn't started a filing yet. You can begin filing now.`
+      status = 'No filing started. You can begin filing now.'
       break
     // in progress
     case 2:
-      status = `${institutionName}'s filing is being processed. You can view the progress.`
+      status = 'The filing is being processed. You can view the progress.'
       break
     // completed
     case 3:
-      status = `${institutionName}'s filing is complete and signed. You can review ${institutionName}'s signed submission.`
+      status = 'The filing is complete and signed. You can review the signed submission.'
       break
       // cancelled
     case 4:
-      status = `${institutionName}'s latest filing has been cancelled. You can review ${institutionName}'s cancelled submission or submit a new file.`
+      status = 'The latest filing has been cancelled. You can review the cancelled submission or submit a new file.'
       break
     default:
-      status = `${institutionName} hasn't started a filing yet. You can begin filing now.`
+      status = 'No filing started. You can begin filing now.'
   }
 
   return <p className="status">{status}</p>
@@ -100,15 +100,11 @@ export default class Institution extends Component {
             ).map((filing, i) => {
               return (
               <div className="usa-grid-full" key={i}>
-                <div className="usa-width-two-thirds">
-                  <h2>{institution.name}</h2>
-                  {renderTiming(filing.status, filing.start, filing.end)}
-                  {renderStatus(filing.status.code, institution.name, filing.institutionId, filing.period)}
-                </div>
-                <div className="usa-width-one-third padding-left-2">
-                  {renderButton(filing.status.code, filing.institutionId, filing.period)}
-                  <Link className="usa-button usa-button-secondary usa-text-small" to={`/${filing.institutionId}/${filing.period}`}>Refile</Link>
-                </div>
+                <h2>{institution.name} - <span className="text-gray">{institution.id}</span></h2>
+                {renderTiming(filing.status, filing.start, filing.end)}
+                {renderStatus(filing.status.code, institution.name, filing.institutionId, filing.period)}
+                {renderButton(filing.status.code, filing.institutionId, filing.period)}
+                <Link className="usa-button usa-button-secondary usa-text-small" to={`/${filing.institutionId}/${filing.period}`}>Refile</Link>
               </div>
               )
             })}

--- a/src/sass/app.scss
+++ b/src/sass/app.scss
@@ -3,7 +3,7 @@
 @import "node_modules/react-select/dist/react-select";
 
 @import "components/DivisionHeader.scss";
-@import "components/InstitutionStatus.scss";
+@import "components/Institutions.scss";
 @import "components/IRSReport.scss";
 @import "components/RefileWarning.scss";
 @import "components/Progress.scss";
@@ -66,6 +66,9 @@ dd {
 .bg-color-red {
   background-color: $color-secondary-dark;
 }
+.bg-color-gray-lightest {
+  background-color: $color-gray-lightest;
+}
 
 // display
 .inline {
@@ -81,4 +84,19 @@ dd {
 }
 .margin-top-0 {
   margin-top: 0;
+}
+
+// padding
+.padding-left-1 {
+  padding-left: 1em;
+}
+.padding-right-1 {
+  padding-right: 1em;
+}
+.padding-left-2 {
+  padding-left: 2em;
+}
+
+.border-left {
+  border-left: 1px solid $color-gray-lightest;
 }

--- a/src/sass/app.scss
+++ b/src/sass/app.scss
@@ -34,3 +34,51 @@ dd {
   margin-bottom: .5em;
   margin-left: 0;
 }
+
+// some basic color classes
+// can be broken out into another file
+
+// text color
+.text-gray {
+  color: $color-gray;
+}
+.text-gray-light {
+  color: $color-gray-light;
+}
+.text-secondary {
+  color: $color-secondary;
+}
+.text-green {
+  color: $color-green;
+}
+.text-primary {
+  color: $color-primary;
+}
+
+.text-uppercase {
+  text-transform: uppercase;
+}
+
+// bg-color
+.bg-color-green {
+  background-color: $color-green;
+}
+.bg-color-red {
+  background-color: $color-secondary-dark;
+}
+
+// display
+.inline {
+  display: inline;
+}
+
+// margins
+.margin-left-1 {
+  margin-left: 1em;
+}
+.margin-bottom-0 {
+  margin-bottom: 0;
+}
+.margin-top-0 {
+  margin-top: 0;
+}

--- a/src/sass/components/InstitutionStatus.scss
+++ b/src/sass/components/InstitutionStatus.scss
@@ -1,7 +1,0 @@
-.institution {
-  margin-bottom: 3em;
-  * {
-    margin-bottom: 0;
-    margin-top: 0;
-  }
-}

--- a/src/sass/components/InstitutionStatus.scss
+++ b/src/sass/components/InstitutionStatus.scss
@@ -1,26 +1,7 @@
-.Institution {
-  margin-top: 30px;
-  &:first-of-type {
-    margin-top: 10px;
-  }
-
-  h3 {
-    font-family: sans-serif;
-    margin-bottom: 0.234em;
-  }
-  h5 {
-    color: #555;
-    margin-bottom: 10px;
+.institution {
+  margin-bottom: 3em;
+  * {
+    margin-bottom: 0;
     margin-top: 0;
   }
-}
-
-.statusLink {
-  margin-bottom: 0.9375em;
-  border-bottom-width: 1px;
-  display: inline-block;
-}
-
-.divisionWrapper {
-  margin-bottom: 25px;
 }

--- a/src/sass/components/Institutions.scss
+++ b/src/sass/components/Institutions.scss
@@ -1,0 +1,14 @@
+.institution {
+  border-top: 1px solid $color-gray-lightest;
+  margin-bottom: 2em;
+  padding-top: 2em;
+  h2,
+  .usa-text-small,
+  .status {
+    margin-bottom: 0;
+    margin-top: 0;
+  }
+  .status {
+    margin-top: .5em;
+  }
+}

--- a/src/sass/components/Institutions.scss
+++ b/src/sass/components/Institutions.scss
@@ -10,5 +10,6 @@
   }
   .status {
     margin-top: .5em;
+    margin-bottom: .5em;
   }
 }


### PR DESCRIPTION
- updates institutions listing page to be a bit more friendly
  - the `status.message` is color coded, green for completed, red for not started and cancelled, and blue for in progress
  - the description text is modified based on the `status.code` too
- adds [moment.js](http://momentjs.com/) to handle time rendering
- adds buttons based on status, with the refile button always present but smaller
- adds column to grid with placeholder text, we can add help text or other messages there
- would like to know if you have thoughts/suggestions on the [`renderTiming`](https://github.com/cfpb/hmda-platform-ui/compare/institutions?expand=1#diff-86bed846ff53cc9ec2c51bcb085621d4R6) and [`renderStatus`](https://github.com/cfpb/hmda-platform-ui/compare/institutions?expand=1#diff-86bed846ff53cc9ec2c51bcb085621d4R26) functions

#### Screenshot
![hmda-fis](https://cloud.githubusercontent.com/assets/2932572/20633989/18238c1e-b31a-11e6-8f44-f8f4a5a7edd4.png)

