### PR TITLE
Navigation and refiling

### DIFF
--- a/src/js/actions/index.js
+++ b/src/js/actions/index.js
@@ -369,9 +369,9 @@ export function requestUpload(file) {
  * Signal the creation of a new submission which will be used for subsequent actions
  */
 
-export function fetchNewSubmission() {
+export function fetchNewSubmission(id, period) {
   return dispatch => {
-    return createSubmission()
+    return createSubmission(id, period)
       .then(json => dispatch(receiveSubmission(json)))
       .catch(err => console.error(err))
   }
@@ -394,7 +394,7 @@ export function fetchSubmission() {
         if(latestSubmission.id.sequenceNumber !== 0){
           return dispatch(receiveSubmission(latestSubmission))
         }else{
-          return createSubmission().then(submission => {
+          return createSubmission(json.filing.institutionId, json.filing.period).then(submission => {
               dispatch(receiveSubmission(submission))
             })
         }

--- a/src/js/actions/index.js
+++ b/src/js/actions/index.js
@@ -365,6 +365,17 @@ export function requestUpload(file) {
     return Promise.resolve()
   }
 }
+
+/*
+ * Signal that submission state should be wiped and a new submission should be created
+ */
+export function createNewSubmission(id, period) {
+  return dispatch => {
+    dispatch(selectFile())
+    return dispatch(fetchNewSubmission(id, period))
+  }
+}
+
 /*
  * Signal the creation of a new submission which will be used for subsequent actions
  */

--- a/src/js/api.js
+++ b/src/js/api.js
@@ -74,8 +74,9 @@ export function getSubmission(id){
   return sendFetch(`/submissions/${id}`)
 }
 
-export function createSubmission(){
-  return sendFetch('/submissions', {method: 'POST'})
+export function createSubmission(id, filing){
+  return sendFetch(`/institutions/${id}/filings/${filing}/submissions`,
+      {method:'POST', noParse:1})
 }
 
 export function getFiling(id, filing){

--- a/src/js/components/Institutions.jsx
+++ b/src/js/components/Institutions.jsx
@@ -129,6 +129,7 @@ export default class Institution extends Component {
         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi nec auctor nisl. Nam ut justo nec ligula aliquam pretium et at orci. Nulla pulvinar feugiat tellus, in sagittis sem sollicitudin at. Nunc nec libero at elit consectetur elementum eu at nisl.</p>
         <p>Curabitur molestie felis massa, vel semper nulla maximus nec. Quisque feugiat nulla nec urna tristique varius. Ut vulputate felis mi, non elementum lacus tempor ut. Etiam tempus porta arcu non venenatis. Vivamus nec tellus eleifend, pulvinar sapien sed, posuere leo.</p>
       </div>
+    </div>
     )
   }
 }

--- a/src/js/components/Institutions.jsx
+++ b/src/js/components/Institutions.jsx
@@ -85,9 +85,10 @@ const renderButton = (code, institutionId, period) => {
   return <Link className="usa-button" to={`/${institutionId}/${period}`}>{buttonText}</Link>
 }
 
-const renderRefile = (code, institutionId, period) => {
+const renderRefile = (createNewSubmission, code, institutionId, period) => {
   if(code === 1) return null
-  return <Link className="usa-button usa-button-secondary usa-text-small" to={`/${institutionId}/${period}`}>Refile</Link>
+  return <a className="usa-button usa-button-secondary usa-text-small" onClick={()=>{
+    createNewSubmission(institutionId, period)}}>Refile</a>
 }
 
 const getInstitutionFromFiling = (institutions, filing) => {
@@ -101,6 +102,7 @@ export default class Institution extends Component {
   render() {
     console.log('inst filings',this.props.institutions, this.props.filings)
     const institutions = this.props.institutions
+    const createNewSubmission = this.props.createNewSubmission
     return (
     <div className="Institutions usa-grid-full">
       <UserHeading period="2017" userName={this.props.user.profile.name} />
@@ -114,7 +116,7 @@ export default class Institution extends Component {
               {renderTiming(filing.status, filing.start, filing.end)}
               {renderStatus(filing.status.code, institution.name, filing.institutionId, filing.period)}
               {renderButton(filing.status.code, filing.institutionId, filing.period)}
-              {renderRefile(filing.status.code, filing.institutionId, filing.period)}
+              {renderRefile(createNewSubmission, filing.status.code, filing.institutionId, filing.period)}
             </div>
           )
         })}
@@ -140,5 +142,5 @@ Institution.propTypes = {
   filings: PropTypes.array,
   user: PropTypes.object,
   institutions: PropTypes.array,
-  dispatch: PropTypes.func.isRequired
+  fetchNewSubmission: PropTypes.func
 }

--- a/src/js/components/Institutions.jsx
+++ b/src/js/components/Institutions.jsx
@@ -85,10 +85,10 @@ const renderButton = (code, institutionId, period) => {
   return <Link className="usa-button" to={`/${institutionId}/${period}`}>{buttonText}</Link>
 }
 
-const renderRefile = (createNewSubmission, code, institutionId, period) => {
+const renderRefile = (makeNewSubmission, code, institutionId, period) => {
   if(code === 1) return null
   return <a className="usa-button usa-button-secondary usa-text-small" onClick={()=>{
-    createNewSubmission(institutionId, period)}}>Refile</a>
+    makeNewSubmission(institutionId, period)}}>Refile</a>
 }
 
 const getInstitutionFromFiling = (institutions, filing) => {
@@ -102,7 +102,7 @@ export default class Institution extends Component {
   render() {
     console.log('inst filings',this.props.institutions, this.props.filings)
     const institutions = this.props.institutions
-    const createNewSubmission = this.props.createNewSubmission
+    const makeNewSubmission = this.props.makeNewSubmission
     return (
     <div className="Institutions usa-grid-full">
       <UserHeading period="2017" userName={this.props.user.profile.name} />
@@ -116,7 +116,7 @@ export default class Institution extends Component {
               {renderTiming(filing.status, filing.start, filing.end)}
               {renderStatus(filing.status.code, institution.name, filing.institutionId, filing.period)}
               {renderButton(filing.status.code, filing.institutionId, filing.period)}
-              {renderRefile(createNewSubmission, filing.status.code, filing.institutionId, filing.period)}
+              {renderRefile(makeNewSubmission, filing.status.code, filing.institutionId, filing.period)}
             </div>
           )
         })}

--- a/src/js/components/NavHeader.jsx
+++ b/src/js/components/NavHeader.jsx
@@ -1,0 +1,31 @@
+import React, { PropTypes } from 'react'
+import { Link } from 'react-router'
+
+const styleSelectedPage = (selected, current) => {
+  if(selected === current) return {textDecoration: 'underline'}
+  return {textDecoration: 'none'}
+}
+
+const NavHeader = (props) => {
+  console.log(props.page, props.base)
+  return (
+    <ul className="NavHeader">
+      <li>
+        <Link style={styleSelectedPage(props.page, 'upload')} to={props.base + '/upload'}>Upload</Link>
+      </li>
+      <li>
+        <Link style={styleSelectedPage(props.page, 'edits')} to={props.base + '/edits'}>Edits</Link>
+      </li>
+      <li>
+        <Link style={styleSelectedPage(props.page, 'summary')} to={props.base + '/summary'}>Summary</Link>
+      </li>
+    </ul>
+  )
+}
+
+NavHeader.propTypes = {
+  page: React.PropTypes.string,
+  base: React.PropTypes.string
+}
+
+export default NavHeader

--- a/src/js/components/RefileWarning.jsx
+++ b/src/js/components/RefileWarning.jsx
@@ -9,7 +9,7 @@ const getText = (props) => {
   let textToRender = null
   let refileLink = null
 
-  if(props.types.hasOwnProperty("syntactical")) {
+  if(props.types.hasOwnProperty('syntactical')) {
     if(props.types.syntactical.edits.length !== 0 || props.types.validity.edits.length !== 0) {
       textToRender = refileText
       refileLink = getRefileLink(props)
@@ -27,7 +27,10 @@ const getText = (props) => {
 }
 
 const getRefileLink = (props) => {
-  return <Link to='' onClick={props.refileLink}>Refile here.</Link>
+  return <a onClick={(e)=>{
+    e.preventDefault()
+    props.refileLink(props.submission.id.institutionId, props.submission.id.period)
+  }}>Refile here.</a>
 }
 
 const RefileWarning = (props) => {
@@ -35,7 +38,7 @@ const RefileWarning = (props) => {
   if (props.submission.status.code > 8) return null
 
   let alertClass = 'usa-alert-error'
-  if(props.types.hasOwnProperty("syntactical")) {
+  if(props.types.hasOwnProperty('syntactical')) {
     if(props.types.syntactical.edits.length === 0 && props.types.validity.edits.length === 0) {
       alertClass = 'usa-alert-warning'
     }

--- a/src/js/components/UploadForm.jsx
+++ b/src/js/components/UploadForm.jsx
@@ -1,18 +1,30 @@
-import React, { PropTypes } from 'react'
+import React, { Component, PropTypes } from 'react'
 import Progress from './Progress.jsx'
 
-const Upload = (props) => (
-  <div className="UploadForm">
-    <form className="usa-form" encType="multipart/form-data" onSubmit={e => props.handleSubmit(e, props.file)}>
-      <input id="hmdaFile" name="hmdaFile" type="file" onChange={props.setFile}></input>
-      <input className="usa-button" id="uploadButton" name="uploadButton" type="submit" value="Upload"></input>
-    </form>
-    {props.file
-      ? <Progress progress={props.bytesUploaded} total={props.file.size} units="bytes" descriptor="uploaded"/>
-      : null
-    }
-  </div>
-)
+class Upload extends Component {
+  constructor(props) {
+    super(props)
+  }
+
+  componentDidUpdate(){
+    if(!this.props.file) this.fileInput.value = ''
+  }
+
+  render() {
+    return (
+    <div className="UploadForm">
+      <form className="usa-form" encType="multipart/form-data" onSubmit={e => this.props.handleSubmit(e, this.props.file)}>
+        <input id="hmdaFile" name="hmdaFile" type="file" ref={(input) => {this.fileInput = input}} onChange={this.props.setFile}></input>
+        <input className="usa-button" id="uploadButton" name="uploadButton" type="submit" value="Upload"></input>
+      </form>
+      {this.props.file
+        ? <Progress progress={this.props.bytesUploaded} total={this.props.file.size} units="bytes" descriptor="uploaded"/>
+        : null
+      }
+    </div>
+    )
+  }
+}
 
 Upload.propTypes = {
   handleSubmit: PropTypes.func,

--- a/src/js/containers/Institutions.jsx
+++ b/src/js/containers/Institutions.jsx
@@ -1,7 +1,7 @@
 import React, { Component } from 'react'
 import { connect } from 'react-redux'
 import { browserHistory } from 'react-router'
-import { updateFilingPeriod, fetchInstitutions, fetchNewSubmission } from '../actions'
+import { updateFilingPeriod, fetchInstitutions, createNewSubmission } from '../actions'
 import Institutions from '../components/Institutions.jsx'
 
 class InstitutionContainer extends Component {
@@ -46,13 +46,13 @@ function mapStateToProps(state) {
 }
 
 function mapDispatchToProps(dispatch){
-  const createNewSubmission = (id, period) => {
-    return dispatch(fetchNewSubmission(id, period)).then(()=>{
+  const makeNewSubmission = (id, period) => {
+    return dispatch(createNewSubmission(id, period)).then(()=>{
       browserHistory.push(`/${id}/${period}`)
     })
   }
 
-  return { createNewSubmission, dispatch }
+  return { makeNewSubmission, dispatch }
 }
 
 InstitutionContainer.defaultProps = {

--- a/src/js/containers/Institutions.jsx
+++ b/src/js/containers/Institutions.jsx
@@ -1,6 +1,7 @@
 import React, { Component } from 'react'
 import { connect } from 'react-redux'
-import { updateFilingPeriod, fetchInstitutions } from '../actions'
+import { browserHistory } from 'react-router'
+import { updateFilingPeriod, fetchInstitutions, fetchNewSubmission } from '../actions'
 import Institutions from '../components/Institutions.jsx'
 
 class InstitutionContainer extends Component {
@@ -44,8 +45,18 @@ function mapStateToProps(state) {
   }
 }
 
+function mapDispatchToProps(dispatch){
+  const createNewSubmission = (id, period) => {
+    return dispatch(fetchNewSubmission(id, period)).then(()=>{
+      browserHistory.push(`/${id}/${period}`)
+    })
+  }
+
+  return { createNewSubmission, dispatch }
+}
+
 InstitutionContainer.defaultProps = {
   user: null
 }
 
-export default connect(mapStateToProps)(InstitutionContainer)
+export default connect(mapStateToProps, mapDispatchToProps)(InstitutionContainer)

--- a/src/js/containers/RefileWarning.jsx
+++ b/src/js/containers/RefileWarning.jsx
@@ -1,6 +1,7 @@
 import { connect } from 'react-redux'
+import { browserHistory } from 'react-router'
 import RefileWarning from '../components/RefileWarning.jsx'
-import { fetchNewSubmission } from '../actions'
+import { createNewSubmission } from '../actions'
 
 function mapStateToProps(state) {
   const {
@@ -25,9 +26,10 @@ function mapStateToProps(state) {
 }
 
 function mapDispatchToProps(dispatch) {
-  const refileLink = (e) => {
-    e.preventDefault()
-    dispatch(fetchNewSubmission())
+  const refileLink = (id, period) => {
+    dispatch(createNewSubmission(id, period)).then(()=>{
+      browserHistory.replace(`/${id}/${period}`)
+    })
   }
 
   return {refileLink}

--- a/src/js/containers/SubmissionRouter.jsx
+++ b/src/js/containers/SubmissionRouter.jsx
@@ -25,8 +25,8 @@ class SubmissionRouter extends Component {
 
     console.log('current status code, from submission router', code)
 
-    // status codes can be found at https://github.com/cfpb/hmda-platform/blob/master/Documents/submission-status.md
-    
+  // status codes can be found at https://github.com/cfpb/hmda-platform/blob/master/Documents/submission-status.md
+
     if(code === -1){
       return (
       <div className="SubmissionContainer">
@@ -35,11 +35,11 @@ class SubmissionRouter extends Component {
       )
     }
 
-    if(code < 7) return browserHistory.push(pathname + '/upload')
+    if(code < 7) return browserHistory.replace(pathname + '/upload')
 
-    if(code < 10) return browserHistory.push(pathname + '/edits')
+    if(code < 10) return browserHistory.replace(pathname + '/edits')
 
-    return browserHistory.push(pathname + '/summary')
+    return browserHistory.replace(pathname + '/summary')
   }
 
   render() {

--- a/src/js/containers/SubmissionRouter.jsx
+++ b/src/js/containers/SubmissionRouter.jsx
@@ -1,0 +1,77 @@
+import React, { Component, PropTypes } from 'react'
+import { connect } from 'react-redux'
+import { browserHistory } from 'react-router'
+import { fetchSubmission } from '../actions'
+
+class SubmissionRouter extends Component {
+  constructor(props) {
+    super(props)
+  }
+
+  componentDidMount() {
+    this.props.dispatch(fetchSubmission())
+      .then((json) => {
+        this.route(this.props)
+      })
+  }
+
+  route(props) {
+    if(!props.user) return null
+    if(!props.status) return null
+
+    const status = props.status
+    const code = status.code
+    const pathname= props.pathname
+
+    console.log('current status code, from submission router', code)
+
+    // status codes can be found at https://github.com/cfpb/hmda-platform/blob/master/Documents/submission-status.md
+    
+    if(code === -1){
+      return (
+      <div className="SubmissionContainer">
+        <p>{status.message}</p>
+      </div>
+      )
+    }
+
+    if(code < 7) return browserHistory.push(pathname + '/upload')
+
+    if(code < 10) return browserHistory.push(pathname + '/edits')
+
+    return browserHistory.push(pathname + '/summary')
+  }
+
+  render() {
+    return null
+  }
+}
+
+function mapStateToProps(state, ownProps) {
+  console.log('submission router state', state)
+  const {
+    status
+  } = state.app.submission || {
+    status: null
+  }
+
+  const user = state.oidc && state.oidc.user || null
+  const pathname = ownProps.location.pathname
+
+  return {
+    status,
+    user,
+    pathname
+  }
+}
+
+SubmissionRouter.propTypes = {
+  dispatch: PropTypes.func.isRequired
+}
+
+SubmissionRouter.defaultProps = {
+  user: null,
+  status: null
+}
+
+export default connect(mapStateToProps)(SubmissionRouter)

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -15,6 +15,7 @@ import oidcCallback from './containers/oidcCallback.jsx'
 import HomeContainer from './containers/Home.jsx'
 import InstitutionContainer from './containers/Institutions.jsx'
 import SubmissionContainer from './containers/Submission.jsx'
+import SubmissionRouter from './containers/SubmissionRouter.jsx'
 import LoginContainer from './containers/Login.jsx'
 import userManager from './UserManager.js'
 
@@ -52,9 +53,9 @@ render(
           <IndexRoute component={HomeContainer}/>
           <Route path="/oidc-callback" component={oidcCallback}/>
           <Route path="/institutions" component={InstitutionContainer}/>
+          <Route path="/:institution/:filing" component={SubmissionRouter}/>
           <Route path="/:institution/:filing/upload" component={SubmissionContainer}/>
-          <Route path="/:institution/:filing/syntax-validity" component={SubmissionContainer}/>
-          <Route path="/:institution/:filing/quality-macro" component={SubmissionContainer}/>
+          <Route path="/:institution/:filing/edits" component={SubmissionContainer}/>
           <Route path="/:institution/:filing/summary" component={SubmissionContainer}/>
         </Route>
       </Router>

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -52,7 +52,10 @@ render(
           <IndexRoute component={HomeContainer}/>
           <Route path="/oidc-callback" component={oidcCallback}/>
           <Route path="/institutions" component={InstitutionContainer}/>
-          <Route path="/:institution/:filing" component={SubmissionContainer}/>
+          <Route path="/:institution/:filing/upload" component={SubmissionContainer}/>
+          <Route path="/:institution/:filing/syntax-validity" component={SubmissionContainer}/>
+          <Route path="/:institution/:filing/quality-macro" component={SubmissionContainer}/>
+          <Route path="/:institution/:filing/summary" component={SubmissionContainer}/>
         </Route>
       </Router>
     </OidcProvider>


### PR DESCRIPTION
Introduces a (very minimally designed) nav which is aware of the app's state and works with refiling.

Known issues:
 - Nav shouldn't be straight links, or rather, only links if those parts have been completed (along with some sort of affordance to show what has been completed or not)
- the links to next items "review edits" etc, should really be a more fully fledged solution, possibly baked in with the refilewarning and/or validation progress. If not baked, they should at least seem cohesive and point the user in the same direction