### PR TITLE
Remove irs verify

### DIFF
--- a/__tests__/IRSReport.js
+++ b/__tests__/IRSReport.js
@@ -17,7 +17,7 @@ describe('IRS report', () => {
   const onIRSClick = jest.fn()
   const irsReport = TestUtils.renderIntoDocument(
     <Wrapper>
-      <IRSReport msas={irsJSON.msas} receipt={irsJSON.receipt} timestamp={irsJSON.timestamp} status={status} onIRSClick={onIRSClick}/>
+      <IRSReport msas={irsJSON.msas} receipt={irsJSON.receipt} timestamp={irsJSON.timestamp} status={status} />
     </Wrapper>
   )
   const irsReportNode = ReactDOM.findDOMNode(irsReport)
@@ -28,47 +28,5 @@ describe('IRS report', () => {
 
   it('creates the correct number of rows', () => {
     expect(TestUtils.scryRenderedDOMComponentsWithTag(irsReport, 'tr').length).toEqual(4)
-  })
-
-  it('contains the checkbox input', () => {
-    expect(TestUtils.scryRenderedDOMComponentsWithTag(irsReport, 'input').length).toEqual(1)
-  })
-
-  it('does NOT render the confirmation', () => {
-    expect(TestUtils.scryRenderedDOMComponentsWithClass(irsReport, 'confirmation').length).toEqual(0)
-  })
-
-  it('calls the function on change', () => {
-    const checkbox = TestUtils.findRenderedDOMComponentWithTag(irsReport, 'input')
-
-    expect(checkbox.checked).toBeFalsy()
-
-    TestUtils.Simulate.change(checkbox, {
-      'target': {
-        'checked': true
-      }
-    })
-
-    expect(onIRSClick).toBeCalled()
-  })
-
-  const statusConfirmed = {
-    code: 11,
-    message: ''
-  }
-  const irsReportConfirmed = TestUtils.renderIntoDocument(
-    <Wrapper>
-      <IRSReport msas={irsJSON.msas} receipt={irsJSON.receipt} timestamp={irsJSON.timestamp} status={statusConfirmed} onIRSClick={onIRSClick}/>
-    </Wrapper>
-  )
-  const irsReportConfirmedNode = ReactDOM.findDOMNode(irsReportConfirmed)
-
-  it('renders the confirmation', () => {
-    expect(TestUtils.findRenderedDOMComponentWithClass(irsReportConfirmed, 'usa-alert-success')).toBeTruthy()
-  })
-
-  it('has the checkbox checked', () => {
-    const checkboxChecked = TestUtils.findRenderedDOMComponentWithTag(irsReportConfirmed, 'input')
-    expect(checkboxChecked.checked).toBeTruthy()
   })
 })

--- a/__tests__/actions.js
+++ b/__tests__/actions.js
@@ -15,7 +15,6 @@ import {
   createSubmission,
   getSubmission,
   getIRS,
-  postIRS,
   getSignature,
   postSignature
 } from '../src/js/api.js'
@@ -32,7 +31,6 @@ getInstitutions.mockImpl(() => Promise.resolve(institutionsObj))
 getLatestSubmission.mockImpl(() => Promise.resolve(filingsObj.filings[0].submissions[2]))
 getSubmission.mockImpl(() => Promise.resolve(filingsObj.filings[0].submissions[2]))
 getIRS.mockImpl((id) => Promise.resolve(IRSObj))
-postIRS.mockImpl((id, verified) => Promise.resolve(IRSObj)) // this won't need the msas, but its already there
 getSignature.mockImpl((id) => Promise.resolve(signatureObj))
 
 const xhrMock = {
@@ -97,25 +95,7 @@ describe('actions', () => {
     const data = IRSObj
     expect(actions.receiveIRS(data)).toEqual({
       type: types.RECEIVE_IRS,
-      msas: data.msas,
-      timestamp: data.timestamp,
-      receipt: data.receipt
-    })
-  })
-
-  it('creates an action to signal a POST request for the IRS report', () => {
-    expect(actions.requestIRSPost()).toEqual({
-      type: types.REQUEST_IRS_POST
-    })
-  })
-
-  it('creates an action to signal a POST request has been received for the IRS report', () => {
-    const verified = { verified: true }
-    const data = IRSObj
-    expect(actions.receiveIRSPost(IRSObj)).toEqual({
-      type: types.RECEIVE_IRS_POST,
-      timestamp: data.timestamp,
-      receipt: data.receipt
+      msas: data.msas
     })
   })
 
@@ -132,7 +112,7 @@ describe('actions', () => {
     })
   })
 
-  it('creates an action to signal the IRS report data has been acquired', () => {
+  it('creates an action to signal the signature data has been acquired', () => {
     const data = signatureObj
     expect(actions.receiveSignature(data)).toEqual({
       type: types.RECEIVE_SIGNATURE,

--- a/__tests__/reducers.js
+++ b/__tests__/reducers.js
@@ -41,8 +41,6 @@ const defaultSignature = {
 const defaultIRS = {
   isFetching: false,
   msas: [],
-  timestamp: null,
-  receipt: null,
   status: defaultSubmission.status
 }
 
@@ -119,26 +117,14 @@ describe('irs reducer', () => {
     ).toEqual({isFetching: true})
   })
 
-  it('handles REQUEST_IRS_POST', () => {
-    expect(
-      irs({}, {type: types.REQUEST_IRS_POST})
-    ).toEqual({isFetching: true})
-  })
-
   it('handles RECEIVE_IRS', () => {
     expect(
-      irs({}, {type: types.RECEIVE_IRS, timestamp: 1234, receipt: 'asdf', msas: []})
-    ).toEqual({isFetching: false, timestamp: 1234, receipt: 'asdf', msas: []})
-  })
-
-  it('handles RECEIVE_IRS_POST', () => {
-    expect(
-      irs({}, {type: types.RECEIVE_IRS_POST, timestamp: 1234, receipt: 'asdf'})
-    ).toEqual({isFetching: false, timestamp: 1234, receipt: 'asdf'})
+      irs({}, {type: types.RECEIVE_IRS, msas: []})
+    ).toEqual({isFetching: false, msas: []})
   })
 
   it('shouldn\'t modify state on an unknown action type', () => {
-    excludeTypes(types.RECEIVE_IRS, types.REQUEST_IRS, types.REQUEST_IRS_POST, types.RECEIVE_IRS_POST)
+    excludeTypes(types.RECEIVE_IRS, types.REQUEST_IRS)
       .forEach(v => expect(irs({}, v))
         .toEqual({})
       )

--- a/server/json/irs.json
+++ b/server/json/irs.json
@@ -32,7 +32,5 @@
       "homeImprovement": 0,
       "refinance": 5
     }
-  ],
-  "timestamp": null,
-  "receipt": null
+  ]
 }

--- a/src/js/actions/index.js
+++ b/src/js/actions/index.js
@@ -11,7 +11,6 @@ import {
   getEditsByRow,
   putEdit,
   getIRS,
-  postIRS,
   getSignature,
   postSignature,
   getSummary,
@@ -178,23 +177,7 @@ export function requestIRS() {
 export function receiveIRS(data) {
   return {
     type: types.RECEIVE_IRS,
-    msas: data.msas,
-    timestamp: data.timestamp,
-    receipt: data.receipt
-  }
-}
-
-export function requestIRSPost() {
-  return {
-    type: types.REQUEST_IRS_POST
-  }
-}
-
-export function receiveIRSPost(data) {
-  return {
-    type: types.RECEIVE_IRS_POST,
-    timestamp: data.timestamp,
-    receipt: data.receipt
+    msas: data.msas
   }
 }
 
@@ -214,24 +197,6 @@ export function fetchIRS() {
       .catch(err => console.error(err))
   }
 }
-
-export function updateIRS(verified) {
-  return dispatch => {
-    dispatch(requestIRSPost())
-    return postIRS(latestSubmissionId, verified)
-      .then(json => {
-        dispatch(receiveIRSPost(json))
-        dispatch(updateStatus(
-          {
-            code: json.status.code,
-            message: json.status.message
-          }
-        ))
-      })
-      .catch(err => console.error(err))
-  }
-}
-
 
 /*
 this is just to set the isFetching value to true

--- a/src/js/api.js
+++ b/src/js/api.js
@@ -108,10 +108,6 @@ export function getIRS(submission){
   return sendFetch(`/submissions/${submission}/irs`);
 }
 
-export function postIRS(submission, data){
-  return sendFetch(`/submissions/${submission}/irs`, {method: 'POST', body: data});
-}
-
 export function getSummary(submission){
   return sendFetch(`/submissions/${submission}/summary`);
 }

--- a/src/js/components/IRSReport.jsx
+++ b/src/js/components/IRSReport.jsx
@@ -1,32 +1,6 @@
 import React, { Component, PropTypes } from 'react'
 import moment from 'moment'
 
-const showConfirmation = (code, timestamp) => {
-  if(code < 11) return null;
-
-  return (
-    <div className="usa-alert usa-alert-success margin-top-1">
-      <div className="usa-alert-body">
-        <h3 className="usa-alert-heading">IRS report verified.</h3>
-        <p className="usa-alert-text">You have verifed your IRS report on <strong>{moment().calendar(timestamp)}</strong>.</p>
-      </div>
-    </div>
-  )
-}
-
-const showWarning = (code) => {
-  if(code > 9) return null
-
-  return (
-    <div className="usa-alert usa-alert-warning margin-top-0">
-      <div className="usa-alert-body">
-        <h3 className="usa-alert-heading">All edits haven't been verified.</h3>
-        <p className="usa-alert-text">You can not verify the IRS report until all edits have been verified and the report has been generated.</p>
-      </div>
-    </div>
-  )
-}
-
 const IRSReport = (props) => {
   if (!props.msas) return null
   const isChecked = props.status.code > 10 ? true : false
@@ -41,8 +15,6 @@ const IRSReport = (props) => {
       </div>
 
       <div className="border margin-bottom-5 padding-1">
-        {showWarning(props.status.code)}
-
         <table width="100%">
           <thead>
             <tr>
@@ -78,21 +50,6 @@ const IRSReport = (props) => {
             })}
           </tbody>
         </table>
-
-        <ul className="usa-unstyled-list">
-          <li>
-            <input id="irs-verify"
-              name="irs-verify"
-              type="checkbox"
-              value="irs-verify"
-              onChange={e => props.onIRSClick(e.target.checked)}
-              checked={isChecked}
-              disabled={isDisabled} />
-            <label htmlFor="irs-verify" className="max-width-100">I have verified that all of the submitted data is correct and agree with the accuracy of the values listed.</label>
-          </li>
-        </ul>
-
-        {showConfirmation(props.status.code, props.timestamp)}
       </div>
     </div>
   )
@@ -100,10 +57,7 @@ const IRSReport = (props) => {
 
 IRSReport.propTypes = {
   msas: PropTypes.array,
-  receipt: PropTypes.string,
-  timestamp: PropTypes.number,
-  status: PropTypes.object,
-  onIRSClick: PropTypes.func.isRequired
+  status: PropTypes.object
 }
 
 IRSReport.defaultProps = {

--- a/src/js/components/Signature.jsx
+++ b/src/js/components/Signature.jsx
@@ -15,21 +15,21 @@ const showReceipt = (code, timestamp, receipt) => {
 }
 
 const showWarning = (code) => {
-  if(code > 10) return null
+  if(code > 8) return null
 
   return (
     <div className="usa-alert usa-alert-warning margin-top-0">
       <div className="usa-alert-body">
-        <h3 className="usa-alert-heading">IRS report hasn't been verified.</h3>
-        <p className="usa-alert-text">You can not sign your submission until the IRS report has been verified.</p>
+        <h3 className="usa-alert-heading">Edits still exist.</h3>
+        <p className="usa-alert-text">You can not sign your submission until all edits have passed or been verified.</p>
       </div>
     </div>
   )
 }
 
 const Signature = (props) => {
-  // if code 11, enable the checkbox
-  const isDisabled = props.status.code === 11 ? false : true
+  // if code greater than 8 (validated) and not 12 (signed), enable the checkbox
+  const isDisabled = (props.status.code > 8 && props.status.code !== 12) ? false : true
 
   let buttonClass = 'usa-button-disabled'
   // if the checkbox is checked remove disabled from button

--- a/src/js/components/Signature.jsx
+++ b/src/js/components/Signature.jsx
@@ -60,7 +60,7 @@ const Signature = (props) => {
               disabled={isDisabled}
               checked={props.checked}
               onChange={e => props.onSignatureCheck(e.target.checked)}/>
-            <label htmlFor="signature" className="max-width-100">I am an authorized representative of my institution with knowledge of the data submitted and can certify to the accuracy and completeness of the data submitted.</label>
+            <label htmlFor="signature" className="max-width-100">I am an authorized representative of my institution with knowledge of the data submitted and am certifying to the accuracy and completeness of the data submitted.</label>
           </li>
         </ul>
 

--- a/src/js/containers/IRSReport.jsx
+++ b/src/js/containers/IRSReport.jsx
@@ -1,6 +1,6 @@
 import React, { Component } from 'react'
 import { connect } from 'react-redux'
-import { fetchIRS, updateIRS } from '../actions'
+import { fetchIRS } from '../actions'
 import IRSReport from '../components/IRSReport.jsx'
 
 class IRSReportContainer extends Component {
@@ -20,14 +20,10 @@ class IRSReportContainer extends Component {
 function mapStateToProps(state) {
   const {
     isFetching,
-    msas,
-    timestamp,
-    receipt
+    msas
   } = state.app.irs || {
     isFetching: true,
-    msas: [],
-    timestamp: null,
-    receipt: null
+    msas: []
   }
 
   const {
@@ -42,19 +38,8 @@ function mapStateToProps(state) {
   return {
     isFetching,
     msas,
-    timestamp,
-    receipt,
     status
   }
 }
 
-function mapDispatchToProps(dispatch) {
-  return {
-    onIRSClick: (verified) => {
-      dispatch(updateIRS({verified: verified}))
-    },
-    dispatch
-  }
-}
-
-export default connect(mapStateToProps, mapDispatchToProps)(IRSReportContainer)
+export default connect(mapStateToProps)(IRSReportContainer)

--- a/src/js/containers/Submission.jsx
+++ b/src/js/containers/Submission.jsx
@@ -39,7 +39,6 @@ class SubmissionContainer extends Component {
     const base = pathname.split('/').slice(0,-1).join('/')
     const page = pathname.split('/').slice(-1)[0]
     const toRender = []
-    console.log('the page is ', page)
     console.log('current status code, from submission container', code)
 
     // status codes can be found at https://github.com/cfpb/hmda-platform/blob/master/Documents/submission-status.md

--- a/src/js/containers/Submission.jsx
+++ b/src/js/containers/Submission.jsx
@@ -39,6 +39,7 @@ class SubmissionContainer extends Component {
     const base = pathname.split('/').slice(0,-1).join('/')
     const page = pathname.split('/').slice(-1)[0]
     const toRender = []
+    console.log('the page is ', page)
     console.log('current status code, from submission container', code)
 
     // status codes can be found at https://github.com/cfpb/hmda-platform/blob/master/Documents/submission-status.md
@@ -57,10 +58,10 @@ class SubmissionContainer extends Component {
           if(code > 8) toRender.push(<Link className='Navlink' to={base + '/summary'}>Review Summary</Link>)
         }
       }else if(page === 'summary'){
-        if(code > 9){
+        if(code > 7){
           toRender.push(<IRSReport/>)
-          toRender.push(<Signature/>)
           toRender.push(<Summary/>)
+          toRender.push(<Signature/>)
         }
       }
     }

--- a/src/js/reducers/index.js
+++ b/src/js/reducers/index.js
@@ -20,8 +20,6 @@ import {
   RECEIVE_EDIT_PUT,
   REQUEST_IRS,
   RECEIVE_IRS,
-  REQUEST_IRS_POST,
-  RECEIVE_IRS_POST,
   REQUEST_SIGNATURE,
   RECEIVE_SIGNATURE,
   REQUEST_SIGNATURE_POST,
@@ -222,8 +220,6 @@ const edits = (state = defaultEdits, action) => {
 const defaultIRS = {
   isFetching: false,
   msas: [],
-  timestamp: null,
-  receipt: null,
   status: defaultSubmission.status
 }
 
@@ -240,23 +236,7 @@ export const irs = (state = defaultIRS, action) => {
       return {
         ...state,
         isFetching: false,
-        msas: action.msas,
-        timestamp: action.timestamp,
-        receipt: action.receipt
-      }
-
-    case REQUEST_IRS_POST:
-      return {
-        ...state,
-        isFetching: true
-      }
-
-    case RECEIVE_IRS_POST:
-      return {
-        ...state,
-        isFetching: false,
-        timestamp: action.timestamp,
-        receipt: action.receipt
+        msas: action.msas
       }
 
     default:


### PR DESCRIPTION
Closes #286 

- does everything in #286, plus
- cleans up `api.js` for the `POST` to `/irs`
- updates `actions` and `reducers` too, basically don't send along `timestamp` and `receipt`

Also this ![pr](https://cloud.githubusercontent.com/assets/2932572/21326364/4b377746-c5f8-11e6-8bd5-25d453251993.png) is cool 😃 

