### PR TITLE
Component tests

### DIFF
--- a/__tests__/EditsHeaderDescription.js
+++ b/__tests__/EditsHeaderDescription.js
@@ -21,8 +21,35 @@ describe('EditsHeaderDescription', function(){
     expect(header.props.children.props.count).toEqual(1)
   })
 
-  it('correctly sets the desc', function(){
+  it('correctly sets the syntactical desc', function(){
     expect(headerNode.textContent).toEqual('Syntactical Edits - 1Edits that check whether the loan/application register is in the correct format and whether the data covers the correct filing year. The loan/application register cannot be filed until the filer corrects all syntactical edit errors and reuploads the updated loan/application register to the HMDA Platform.')
+  })
+
+  const headerValidity = TestUtils.renderIntoDocument(
+    <Wrapper><EditsHeaderDescription type="validity" count={1} /></Wrapper>
+  )
+  const headerValidityNode = ReactDOM.findDOMNode(headerValidity)
+
+  it('correctly sets the validity desc', function(){
+    expect(headerValidityNode.textContent).toEqual('Validity Edits - 1Edits that check whether there are valid values in each data field. The loan/application register cannot be filed until the filer corrects all validity edit errors and reuploads the updated loan/application register to the HMDA Platform.')
+  })
+
+  const headerQuality = TestUtils.renderIntoDocument(
+    <Wrapper><EditsHeaderDescription type="quality" count={1} /></Wrapper>
+  )
+  const headerQualityNode = ReactDOM.findDOMNode(headerQuality)
+
+  it('correctly sets the Quality desc', function(){
+    expect(headerQualityNode.textContent).toEqual('Quality Edits - 1Edits that check whether entries in the individual data fields or combinations of data fields conform to expected values. The loan/application register cannot be filed until the filer either confirms the accuracy of all values flagged by quality edits in the HMDA Platform, or corrects the flagged values and reuploads the updated loan/application register to the HMDA Platform.')
+  })
+
+  const headerMarcro = TestUtils.renderIntoDocument(
+    <Wrapper><EditsHeaderDescription type="macro" count={1} /></Wrapper>
+  )
+  const headerMarcroNode = ReactDOM.findDOMNode(headerMarcro)
+
+  it('correctly sets the Quality desc', function(){
+    expect(headerMarcroNode.textContent).toEqual('Macro Edits - 1Edits that check whether the submitted loan/application register as a whole conforms to expected values. The loan/application register cannot be filed until the filer either confirms the accuracy of all the values flagged by the macro quality edits in the HMDA Platform or corrects the flagged values and reuploads the updated loan/application register to the HMDA Platform.')
   })
 
   const headerLAR = TestUtils.renderIntoDocument(
@@ -30,8 +57,28 @@ describe('EditsHeaderDescription', function(){
   )
   const headerLARNode = ReactDOM.findDOMNode(headerLAR)
 
-  it('correctly sets the desc', function(){
+  it('correctly sets the LAR desc', function(){
     expect(headerLARNode.textContent).toEqual('Loan Application Records - 1LAR refers to the loan/application register. Loan/Application Register means both the record of information required to be collected pursuant to § 1003.4 and the record submitted annually or quarterly, as applicable, pursuant to § 1003.5(a).')
+  })
+
+  it('throws an error for a bad type', () => {
+    const getText = jest.fn()
+    try {
+      TestUtils.renderIntoDocument(<Wrapper><EditsHeaderDescription type="blahblah" count={1} /></Wrapper>)
+      expect(getText).toBeCalledWith('blaasdfhblah')
+    }
+    catch(err) {
+      expect(err.message).toEqual('Unexpected edit type. Unable to create edit description')
+    }
+  })
+
+  it('throws an error for a missing type', () => {
+    try {
+      TestUtils.renderIntoDocument(<Wrapper><EditsHeaderDescription type="" count={1} /></Wrapper>)
+    }
+    catch(err) {
+      expect(err.message).toEqual('Unexpected edit type. Unable to create edit description')
+    }
   })
 
 })

--- a/__tests__/EditsHeaderDescription.js
+++ b/__tests__/EditsHeaderDescription.js
@@ -64,8 +64,7 @@ describe('EditsHeaderDescription', function(){
   it('throws an error for a bad type', () => {
     const getText = jest.fn()
     try {
-      TestUtils.renderIntoDocument(<Wrapper><EditsHeaderDescription type="blahblah" count={1} /></Wrapper>)
-      expect(getText).toBeCalledWith('blaasdfhblah')
+      TestUtils.renderIntoDocument(<Wrapper><EditsHeaderDescription type="badType" count={1} /></Wrapper>)
     }
     catch(err) {
       expect(err.message).toEqual('Unexpected edit type. Unable to create edit description')

--- a/__tests__/Login.js
+++ b/__tests__/Login.js
@@ -1,0 +1,30 @@
+jest.unmock('../src/js/components/Login.jsx')
+
+import Login from '../src/js/components/Login.jsx'
+import Wrapper from './Wrapper.js'
+import React from 'react'
+import ReactDOM from 'react-dom'
+import TestUtils from 'react-addons-test-utils'
+
+describe('login', () => {
+  const redirect = jest.fn()
+  const login = TestUtils.renderIntoDocument(
+    <Wrapper><Login redirect={redirect} /></Wrapper>
+  );
+  const loginNode = ReactDOM.findDOMNode(login)
+
+  it('renders the header', () => {
+    expect(loginNode).toBeDefined()
+  })
+
+  it('renders correctly', () => {
+    expect(loginNode.textContent).toEqual('Welcome to HMDA Filing, please login here')
+  })
+
+  it('calls the function on click', () => {
+    var link = TestUtils.findRenderedDOMComponentWithTag(login, 'a')
+    TestUtils.Simulate.click(link)
+    expect(redirect).toBeCalled()
+  })
+
+})

--- a/__tests__/RefileWarning.js
+++ b/__tests__/RefileWarning.js
@@ -11,6 +11,7 @@ import { parseLocation } from '../src/js/api'
 parseLocation.mockImpl(() => { return { id:'1', period: '2017', submission: 1 } })
 
 describe('Refile Warning', () => {
+  const parserText = 'Parsing errors require file resubmission.'
   const refileText = 'Syntactical and validity edits require file resubmission.';
   const validateText = 'Quality and macro edits must be validated before continuing.';
   const synTypes = {
@@ -26,6 +27,36 @@ describe('Refile Warning', () => {
     quality: {edits: []},
     macro: {edits: []}
   }
+
+  it('renders the correct elements for status code 5 and calls function on click', () => {
+    const submission = {
+      status: {
+        code: 5,
+        message: ''
+      },
+      id: {
+        institutionId: '12345',
+        period: '2017',
+        sequenceNumber: 1
+      }
+    }
+
+    const refileLink = jest.fn()
+
+    const refileWarning = TestUtils.renderIntoDocument(
+      <Wrapper>
+        <RefileWarning submission={submission} types={synTypes} refileLink={refileLink}/>
+      </Wrapper>
+    )
+
+    expect(TestUtils.findRenderedDOMComponentWithClass(refileWarning, 'usa-alert-heading').innerHTML.match(parserText)[0]).toEqual(parserText);
+    expect(TestUtils.scryRenderedDOMComponentsWithTag(refileWarning, 'a').length).toEqual(1);
+
+    const link = TestUtils.findRenderedDOMComponentWithTag(refileWarning, 'a')
+    TestUtils.Simulate.click(link)
+    expect(refileLink).toBeCalled()
+    expect(refileLink).toBeCalledWith('12345', '2017')
+  });
 
   it('renders the correct elements for status code 7', () => {
     const submission = {

--- a/__tests__/Signature.js
+++ b/__tests__/Signature.js
@@ -31,6 +31,10 @@ describe('Signature component', () => {
     expect(TestUtils.scryRenderedDOMComponentsWithTag(signature, 'input').length).toEqual(1)
   })
 
+  it('contains the submit button', () => {
+    expect(TestUtils.scryRenderedDOMComponentsWithTag(signature, 'button').length).toEqual(1)
+  })
+
   it('does NOT render the receipt and hash', () => {
     expect(TestUtils.scryRenderedDOMComponentsWithClass(signature, 'usa-alert-success').length).toEqual(0)
   })
@@ -64,6 +68,15 @@ describe('Signature component', () => {
     expect(TestUtils.scryRenderedDOMComponentsWithClass(buttonEnabled, 'usa-button-disabled').length).toEqual(0)
   })
 
+  it('calls the function on click', () => {
+    var button = TestUtils.findRenderedDOMComponentWithTag(signature, 'button')
+    //expect(b.checked).toBeFalsy()
+
+    TestUtils.Simulate.click(button,)
+
+    expect(onSignatureClick).toBeCalled()
+  })
+
   // checkbox checked and status is signed
   const statusSigned = {
     code: 12,
@@ -83,5 +96,29 @@ describe('Signature component', () => {
   it('has the checkbox checked', () => {
     const checkboxChecked = TestUtils.findRenderedDOMComponentWithTag(signatureSigned, 'input')
     expect(checkboxChecked.checked).toBeTruthy()
+  })
+
+  it('has the checkbox disabled', () => {
+    const checkboxDisabled = TestUtils.findRenderedDOMComponentWithTag(signatureSigned, 'input')
+    expect(checkboxDisabled.disabled).toBeTruthy()
+  })
+
+  it('has the button disabled', () => {
+    expect(TestUtils.findRenderedDOMComponentWithClass(signatureSigned, 'usa-button-disabled')).toBeTruthy()
+  })
+
+  const statusEdits = {
+    code: 7,
+    message: ''
+  }
+  const signatureWithEdits = TestUtils.renderIntoDocument(
+    <Wrapper>
+      <Signature checked={true} receipt={signJSON.receipt} timestamp={signJSON.timestamp} status={statusEdits} onSignatureClick={onSignatureClick} onSignatureCheck={onSignatureCheck}/>
+    </Wrapper>
+  )
+  const signatureWithEditsNode = ReactDOM.findDOMNode(signatureWithEdits)
+
+  it('renders the warning', () => {
+    expect(TestUtils.findRenderedDOMComponentWithClass(signatureWithEdits, 'usa-alert-warning')).toBeTruthy()
   })
 })

--- a/__tests__/Signature.js
+++ b/__tests__/Signature.js
@@ -69,10 +69,9 @@ describe('Signature component', () => {
   })
 
   it('calls the function on click', () => {
-    var button = TestUtils.findRenderedDOMComponentWithTag(signature, 'button')
-    //expect(b.checked).toBeFalsy()
+    var button = TestUtils.findRenderedDOMComponentWithTag(buttonEnabled, 'button')
 
-    TestUtils.Simulate.click(button,)
+    TestUtils.Simulate.click(button)
 
     expect(onSignatureClick).toBeCalled()
   })

--- a/__tests__/UploadForm.js
+++ b/__tests__/UploadForm.js
@@ -11,7 +11,9 @@ describe('submitform', function(){
   const handleSubmit = jest.fn()
   const setFile = jest.fn()
 
-  const form = TestUtils.renderIntoDocument(
+  // use ReactDOM.render instead to be able to test componentDidUpdate
+  const node = document.createElement('div')
+  const form = ReactDOM.render(
       <Wrapper>
         <UploadForm
           handleSubmit={handleSubmit}
@@ -20,11 +22,16 @@ describe('submitform', function(){
           bytesUploaded={42}
           file={{size:108}}
         />
-      </Wrapper>)
+      </Wrapper>, node)
   const formNode = ReactDOM.findDOMNode(form)
 
   it('renders the form', function(){
     expect(formNode).toBeDefined()
+  })
+
+  it('expects the file input to be empty', () => {
+    const input = TestUtils.scryRenderedDOMComponentsWithTag(form, 'input')[0]
+    expect(input.value).toEqual('')
   })
 
   TestUtils.Simulate.change(
@@ -44,6 +51,21 @@ describe('submitform', function(){
     expect(handleSubmit).toBeCalled()
   })
 
+  const form2 = ReactDOM.render(
+      <Wrapper>
+        <UploadForm
+          handleSubmit={handleSubmit}
+          setFile={setFile}
+          uploading={true}
+          bytesUploaded={42}
+          file={{size:200}}
+        />
+      </Wrapper>, node)
+  const form2Node = ReactDOM.findDOMNode(form2)
+
+  it('expects the file input to be empty', () => {
+    const input = TestUtils.scryRenderedDOMComponentsWithTag(form2, 'input')[0]
+    expect(input.value).toEqual('')
+  })
+
 })
-
-

--- a/src/js/components/RefileWarning.jsx
+++ b/src/js/components/RefileWarning.jsx
@@ -1,7 +1,7 @@
 import React, { PropTypes } from 'react'
 import { Link } from 'react-router'
 
-const parserText = 'Parsing error require file resubmission.'
+const parserText = 'Parsing errors require file resubmission.'
 const refileText = 'Syntactical and validity edits require file resubmission.'
 const validateText = 'Quality and macro edits must be validated before continuing.'
 
@@ -34,7 +34,6 @@ const getRefileLink = (props) => {
 }
 
 const RefileWarning = (props) => {
-  //if(!props.types.syntactical) return null
   if (props.submission.status.code > 8) return null
 
   let alertClass = 'usa-alert-error'


### PR DESCRIPTION
Get us close to 100% coverage for `js/components`.
The only thing missing _from the current tests (we do need a few more)_ is from `EditsByType` which I think is better left until after #305 is merged.

#### Jest report _(`js/components` is the important part)_
```
-----------------------------|----------|----------|----------|----------|----------------|
File                         |  % Stmts | % Branch |  % Funcs |  % Lines |Uncovered Lines |
-----------------------------|----------|----------|----------|----------|----------------|
All files                    |    64.76 |    61.38 |    47.52 |    66.54 |                |
 js                          |    13.56 |        0 |    11.54 |    15.69 |                |
  EditReports.jsx            |      100 |      100 |      100 |      100 |                |
  api.js                     |        0 |        0 |        0 |        0 |... 116,120,124 |
 js/actions                  |    39.74 |    43.75 |    35.58 |       40 |                |
  index.js                   |    39.74 |    43.75 |    35.58 |       40 |... 518,519,520 |
 js/components               |    95.48 |    78.75 |      100 |    99.38 |                |
  DivisionHeader.jsx         |      100 |      100 |      100 |      100 |                |
  EditsByType.jsx            |    90.91 |    83.33 |      100 |    90.91 |             20 |
  EditsHeaderDescription.jsx |      100 |      100 |      100 |      100 |                |
  EditsTableCell.jsx         |    81.82 |       50 |      100 |      100 |                |
  EditsTableRow.jsx          |      100 |       50 |      100 |      100 |                |
  HomeLink.jsx               |      100 |      100 |      100 |      100 |                |
  IRSReport.jsx              |       90 |       50 |      100 |      100 |                |
  Login.jsx                  |      100 |      100 |      100 |      100 |                |
  Progress.jsx               |      100 |      100 |      100 |      100 |                |
  RefileWarning.jsx          |      100 |    88.89 |      100 |      100 |                |
  Signature.jsx              |      100 |      100 |      100 |      100 |                |
  Summary.jsx                |       80 |       50 |      100 |      100 |                |
  UploadForm.jsx             |    85.71 |       50 |      100 |      100 |                |
  UserHeading.jsx            |      100 |      100 |      100 |      100 |                |
  ValidationProgress.jsx     |    88.89 |       50 |      100 |      100 |                |
 js/constants                |      100 |      100 |      100 |      100 |                |
  index.js                   |      100 |      100 |      100 |      100 |                |
 js/containers               |    46.51 |       40 |    34.78 |     47.5 |                |
  App.jsx                    |    83.33 |       50 |      100 |      100 |                |
  EditsTable.jsx             |    77.78 |       50 |    66.67 |    81.25 |       26,37,38 |
  JustificationSelector.jsx  |     6.67 |        0 |        0 |     6.67 |... 54,55,56,61 |
  Login.jsx                  |        0 |      100 |        0 |        0 |    10,14,19,21 |
 js/reducers                 |    79.17 |    79.17 |    91.67 |    80.28 |                |
  index.js                   |    79.17 |    79.17 |    91.67 |    80.28 |... 213,307,313 |
-----------------------------|----------|----------|----------|----------|----------------|
```