### PR TITLE
CSV download and updates to match the edit API

### DIFF
--- a/__tests__/components/EditsByType.js
+++ b/__tests__/components/EditsByType.js
@@ -15,9 +15,7 @@ const types = {
   syntactical: JSON.parse(fs.readFileSync('./__tests__/json/syntactical.json')),
   validity: JSON.parse(fs.readFileSync('./__tests__/json/validity.json')),
   quality: JSON.parse(fs.readFileSync('./__tests__/json/quality.json')),
-  macro: {
-    "edits": []
-  }
+  macro: JSON.parse(fs.readFileSync('./__tests__/json/macro.json'))
 }
 
 const typesNoMacro = {

--- a/__tests__/components/EditsByType.js
+++ b/__tests__/components/EditsByType.js
@@ -28,32 +28,24 @@ const typesNoMacro = {
 }
 
 describe('EditsByType', function() {
-  const editsByType = TestUtils.renderIntoDocument(
-    <Wrapper><EditsByType types={types}/></Wrapper>
-  )
-  const editsByTypeNode = ReactDOM.findDOMNode(editsByType)
-
-  it('renders the component', function() {
-    expect(editsByTypeNode).toBeDefined()
-  })
-
   it('properly renders child elements', function() {
-    expect(TestUtils.scryRenderedDOMComponentsWithClass(editsByType, 'EditsContainerEntry').length).toEqual(4)
-    expect(TestUtils.scryRenderedDOMComponentsWithClass(editsByType, 'EditsHeaderDescription').length).toEqual(4)
-    expect(TestUtils.scryRenderedDOMComponentsWithTag(editsByType, 'table').length).toEqual(6)
-  })
+    const renderer = TestUtils.createRenderer()
+    const renderedEdits = renderer.render(
+      <EditsByType types={typesNoMacro}/>
+    )
+    const editsByType = renderer.getRenderOutput()
 
-  const editsByTypeNoMacro = TestUtils.renderIntoDocument(
-    <Wrapper><EditsByType types={typesNoMacro}/></Wrapper>
-  )
-  const editsByTypeNoMacroNode = ReactDOM.findDOMNode(editsByTypeNoMacro)
+    expect(editsByType.props.children.length).toEqual(4)
+  })
 
   it('properly renders child elements when no macro edits are present', function() {
-    expect(TestUtils.scryRenderedDOMComponentsWithClass(editsByTypeNoMacro, 'EditsContainerEntry').length).toEqual(4)
-    expect(TestUtils.scryRenderedDOMComponentsWithClass(editsByTypeNoMacro, 'EditsHeaderDescription').length).toEqual(4)
-    expect(TestUtils.scryRenderedDOMComponentsWithTag(editsByTypeNoMacro, 'table').length).toEqual(6)
-    // this includes table captions and error, warning, and success messages
-    expect(TestUtils.scryRenderedDOMComponentsWithTag(editsByTypeNoMacro, 'h3').length).toEqual(7)
+    const renderer = TestUtils.createRenderer()
+    const renderedEdits = renderer.render(
+      <EditsByType types={typesNoMacro}/>
+    )
+    const editsByTypeNoMacro = renderer.getRenderOutput()
+
+    expect(editsByTypeNoMacro.props.children.length).toEqual(4)
   })
 
 })

--- a/__tests__/json/macro.json
+++ b/__tests__/json/macro.json
@@ -1,37 +1,22 @@
 {
-  "type": "macro",
   "edits": [
     {
-      "edit": "m1",
+      "edit": "Q008",
       "justifications": [
         {
-          "value":"A very long explanation of why this macro edit failure is in fact fine. expected, a-okay, and all-around stupendous.", 
-          "selected": false
+          "id": 1,
+          "value": "Applicants decided not to proceed with the loan.",
+          "verified": false
         },
         {
-          "value":"B", 
-          "selected": true 
+          "id": 2,
+          "value": "There were a large number of applications, but few loans were closed",
+          "verified": false
         },
         {
-          "value":"C", 
-          "selected": false
-        },
-        {
-          "selected": true,
-          "value": "some custom data"
-        }
-      ]
-    },
-    {
-      "edit": "m2",
-      "justifications": [
-        {
-          "value": "don't worry",
-          "selected": false
-        },
-        {
-          "value": "be happy",
-          "selected": false
+          "id": 3,
+          "value": "Loan activity for this filing year consisted mainly of purchased loans.",
+          "verified": false
         }
       ]
     }

--- a/__tests__/json/quality.json
+++ b/__tests__/json/quality.json
@@ -1,30 +1,29 @@
-  {
-  "type":"quality",
+{
   "edits": [
     {
       "edit": "quality1337",
       "verified": false,
-      "lars": [
+      "rows": [
         {
-          "lar": {"loanId": "q1"}
+          "row": {"rowId": "q1"}
         },
         {
-          "lar": {"loanId": "q2"}
+          "row": {"rowId": "q2"}
         },
         {
-          "lar": {"loanId": "q3"}
+          "row": {"rowId": "q3"}
         }
       ]
     },
     {
       "edit": "quality1338",
       "verified": true,
-      "lars": [
+      "rows": [
         {
-          "lar": {"loanId": "q4"}
+          "row": {"rowId": "q4"}
         },
         {
-          "lar": {"loanId": "q5"}
+          "row": {"rowId": "q5"}
         }
       ]
     }

--- a/__tests__/json/syntactical.json
+++ b/__tests__/json/syntactical.json
@@ -1,30 +1,28 @@
 {
-  "type": "syntactical",
-  "edits": [
-    {
-      "edit": "synedit1",
-      "lars": [
-        {
-          "lar": {"loanId": "s1"}
-        },
-        {
-          "lar": {"loanId": "s2"}
-        },
-        {
-          "lar": {"loanId": "s3"}
-        }
-      ]
-    },
-    {
-      "edit": "synedit2",
-      "lars": [
-        {
-          "lar": {"loanId": "s4"}
-        },
-        {
-          "lar": {"loanId": "s5"}
-        }
-      ]
-    }
-  ]
+    "edits": [
+      {
+        "edit": "S020",
+        "description": "Agency code must = 1, 2, 3, 5, 7, 9. The agency that submits the data must be the same as the reported agency code.",
+        "rows": [
+          {
+            "row": { "rowId": "Transmittal Sheet" }
+          },
+          {
+            "row": { "rowId": "8299422144" }
+          },
+          {
+            "row": { "rowId": "2185751599" }
+          }
+        ]
+      },
+      {
+        "edit": "S010",
+        "description": "The first record identifier in the file must = 1 (TS). The second and all subsequent record identifiers must = 2 (LAR).",
+        "rows": [
+          {
+            "row": { "rowId": "2185751599" }
+          }
+        ]
+      }
+    ]
 }

--- a/__tests__/json/validity.json
+++ b/__tests__/json/validity.json
@@ -1,28 +1,11 @@
 {
-  "type": "validity",
   "edits": [
     {
-      "edit": "valedit1",
-      "lars": [
+      "edit": "V555",
+      "description": "If loan purpose = 1 or 3, then lien status must = 1, 2, or 4.",
+      "rows": [
         {
-          "lar": {"loanId": "v1"}
-        },
-        {
-          "lar": {"loanId": "v2"}
-        },
-        {
-          "lar": {"loanId": "v3"}
-        }
-      ]
-    },
-    {
-      "edit": "valedit2",
-      "lars": [
-        {
-          "lar": {"loanId": "v4"}
-        },
-        {
-          "lar": {"loanId": "v5"}
+          "row": { "rowId": "4977566612" }
         }
       ]
     }

--- a/src/js/actions/index.js
+++ b/src/js/actions/index.js
@@ -535,8 +535,6 @@ export function fetchEditsByType() {
     dispatch(requestEditsByType())
     return getEditsByType(latestSubmissionId)
       .then(json => {
-        console.log('fetchEditsByType')
-        console.log(json)
         dispatch(receiveEditsByType(json))
       })
       .catch(err => console.error(err))

--- a/src/js/actions/index.js
+++ b/src/js/actions/index.js
@@ -112,7 +112,6 @@ export function requestEditsByRow() {
 }
 
 export function receiveEditsByType(data) {
-  console.log('edits by type', data)
   return {
     type: types.RECEIVE_EDITS_BY_TYPE,
     edits: data
@@ -290,6 +289,50 @@ export function fetchSummary() {
     return getSummary(latestSubmissionId)
       .then(json => dispatch(receiveSummary(json)))
       .catch(err => console.error(err))
+  }
+}
+
+// used to trigger csv download properly
+function detectIE() {
+  const ua = window.navigator.userAgent;
+
+  const msie = ua.indexOf('MSIE ');
+  if (msie > 0) {
+      // IE 10 or older => return version number
+      return parseInt(ua.substring(msie + 5, ua.indexOf('.', msie)), 10);
+  }
+
+  const trident = ua.indexOf('Trident/');
+  if (trident > 0) {
+      // IE 11 => return version number
+      var rv = ua.indexOf('rv:');
+      return parseInt(ua.substring(rv + 3, ua.indexOf('.', rv)), 10);
+  }
+
+  const edge = ua.indexOf('Edge/');
+  if (edge > 0) {
+     // IE 12 => return version number
+     return parseInt(ua.substring(edge + 5, ua.indexOf('.', edge)), 10);
+  }
+
+  // other browser
+  return false;
+}
+
+// downloading the csv edit reports, no reducer required
+export function requestCSV(institutionId, submissionId, period) {
+  return dispatch => {
+    dispatch(requestEditsByType())
+    return getEditsByType(submissionId, institutionId, period, {format: 'csv'})
+      .then(csv => {
+        // trigger the download
+        if (detectIE() === false) {
+          window.open('data:text/csv;charset=utf-8,' + encodeURIComponent(csv));
+        } else {
+          var blob = new Blob([csv], {type: 'text/csv;charset=utf-8,'});
+          navigator.msSaveOrOpenBlob(blob, 'rural-or-underserved.csv');
+        }
+      })
   }
 }
 
@@ -491,7 +534,11 @@ export function fetchEditsByType() {
   return dispatch => {
     dispatch(requestEditsByType())
     return getEditsByType(latestSubmissionId)
-      .then(json => dispatch(receiveEditsByType(json)))
+      .then(json => {
+        console.log('fetchEditsByType')
+        console.log(json)
+        dispatch(receiveEditsByType(json))
+      })
       .catch(err => console.error(err))
   }
 }

--- a/src/js/actions/index.js
+++ b/src/js/actions/index.js
@@ -297,20 +297,20 @@ function detectIE() {
   const ua = window.navigator.userAgent;
 
   const msie = ua.indexOf('MSIE ');
-  if (msie > 0) {
+  if (msie >= 0) {
       // IE 10 or older => return version number
       return parseInt(ua.substring(msie + 5, ua.indexOf('.', msie)), 10);
   }
 
   const trident = ua.indexOf('Trident/');
-  if (trident > 0) {
+  if (trident >= 0) {
       // IE 11 => return version number
       var rv = ua.indexOf('rv:');
       return parseInt(ua.substring(rv + 3, ua.indexOf('.', rv)), 10);
   }
 
   const edge = ua.indexOf('Edge/');
-  if (edge > 0) {
+  if (edge >= 0) {
      // IE 12 => return version number
      return parseInt(ua.substring(edge + 5, ua.indexOf('.', edge)), 10);
   }
@@ -330,7 +330,7 @@ export function requestCSV(institutionId, submissionId, period) {
           window.open('data:text/csv;charset=utf-8,' + encodeURIComponent(csv));
         } else {
           var blob = new Blob([csv], {type: 'text/csv;charset=utf-8,'});
-          navigator.msSaveOrOpenBlob(blob, 'rural-or-underserved.csv');
+          navigator.msSaveOrOpenBlob(blob, 'edits.csv');
         }
       })
   }

--- a/src/js/api.js
+++ b/src/js/api.js
@@ -2,7 +2,8 @@ import fetch from 'isomorphic-fetch'
 
 let accessToken
 
-function createQueryString(suffix, params, length) {
+function createQueryString(suffix, params) {
+  const length = Object.keys(params).length
   let newSuffix = `${suffix}?`
   let count = 0
   for(let key of Object.keys(params)) {
@@ -17,9 +18,8 @@ function sendFetch(suffix, options = {method: 'GET'}){
   var locationObj = options.noParse ? {} : parseLocation(location);
   // check if params exist and update suffix to add them
   if(options.params && Object.keys(options.params).length !== 0) {
-    suffix = createQueryString(suffix, options.params, Object.keys(options.params).length)
+    suffix = createQueryString(suffix, options.params)
   }
-  console.log(suffix)
   var url = makeUrl(locationObj, suffix);
   if(typeof options.body === 'object') options.body = JSON.stringify(options.body)
   var headers = {}
@@ -47,11 +47,9 @@ function sendFetch(suffix, options = {method: 'GET'}){
   return fetch(url, fetchOptions)
     .then(response => {
       if(options.params && options.params.format === 'csv') {
-        //console.log(response.text())
         return response.text()
       }
       const json = response.json()
-      console.log('respose from fetch', response, json)
       return json
     })
 }
@@ -121,7 +119,7 @@ export function getEditsByType(submission, institutionId, period, params){
   if(params) {
     return sendFetch(`/institutions/${institutionId}/filings/${period}/submissions/${submission}/edits`, {noParse:1, params:params})
   }
-  return sendFetch(`/submissions/${submission}/edits`, {params:params})
+  return sendFetch(`/submissions/${submission}/edits`)
 }
 
 export function getEditsByRow(submission){

--- a/src/js/api.js
+++ b/src/js/api.js
@@ -2,8 +2,24 @@ import fetch from 'isomorphic-fetch'
 
 let accessToken
 
+function createQueryString(suffix, params, length) {
+  let newSuffix = `${suffix}?`
+  let count = 0
+  for(let key of Object.keys(params)) {
+    newSuffix = `${newSuffix}${key}=${params[key]}`
+    count++
+    if(count < length) newSuffix = `${newSuffix}&`
+  }
+  return newSuffix
+}
+
 function sendFetch(suffix, options = {method: 'GET'}){
   var locationObj = options.noParse ? {} : parseLocation(location);
+  // check if params exist and update suffix to add them
+  if(options.params && Object.keys(options.params).length !== 0) {
+    suffix = createQueryString(suffix, options.params, Object.keys(options.params).length)
+  }
+  console.log(suffix)
   var url = makeUrl(locationObj, suffix);
   if(typeof options.body === 'object') options.body = JSON.stringify(options.body)
   var headers = {}
@@ -11,6 +27,12 @@ function sendFetch(suffix, options = {method: 'GET'}){
   if (options.method === 'POST') {
     headers = {
       'Content-Type': 'application/json'
+    }
+  }
+
+  if(options.params && options.params.format === 'csv') {
+    headers = {
+      'Content-Type': 'text/csv'
     }
   }
 
@@ -24,6 +46,10 @@ function sendFetch(suffix, options = {method: 'GET'}){
   console.log('fetching from', url, 'with options', fetchOptions)
   return fetch(url, fetchOptions)
     .then(response => {
+      if(options.params && options.params.format === 'csv') {
+        //console.log(response.text())
+        return response.text()
+      }
       const json = response.json()
       console.log('respose from fetch', response, json)
       return json
@@ -91,8 +117,11 @@ export function getLatestSubmission(){
   return sendFetch('/submissions/latest')
 }
 
-export function getEditsByType(submission){
-  return sendFetch(`/submissions/${submission}/edits`)
+export function getEditsByType(submission, institutionId, period, params){
+  if(params) {
+    return sendFetch(`/institutions/${institutionId}/filings/${period}/submissions/${submission}/edits`, {noParse:1, params:params})
+  }
+  return sendFetch(`/submissions/${submission}/edits`, {params:params})
 }
 
 export function getEditsByRow(submission){

--- a/src/js/components/EditsByType.jsx
+++ b/src/js/components/EditsByType.jsx
@@ -16,12 +16,12 @@ const renderTables = (editObj, type) => {
     )
   }
 
-  if(edits[0] && !edits[0].lars){
-    return <EditsTable data={edits} type={type} />
+  if(type === 'macro'){
+    return <EditsTable edits={edits} type={type} />
   }
 
   return edits.map((edit, i) => {
-    return <EditsTable lars={edit.lars} ts={edit.ts} type={type} label={edit.edit} desc={edit.description} key={i}/>
+    return <EditsTable edits={edit} type={type} key={i}/>
   })
 }
 

--- a/src/js/components/EditsTableRow.jsx
+++ b/src/js/components/EditsTableRow.jsx
@@ -4,7 +4,7 @@ import EditsTableCell from '../components/EditsTableCell.jsx'
 
 const EditsTableRow = props => {
   const edit = props.row.edit
-  const lar = props.row.loanId
+  const lar = props.row.rowId
   return <tr>
     {
       Object.keys(props.row).map((field, i) => {
@@ -23,4 +23,3 @@ EditsTableRow.defaultProps = {
 }
 
 export default EditsTableRow
-

--- a/src/js/components/Institutions.jsx
+++ b/src/js/components/Institutions.jsx
@@ -118,7 +118,7 @@ export default class Institution extends Component {
               <h5>Previous submissions for this filing</h5>
               <ul className="usa-text-small usa-unstyled-list">
                 {filingObj.submissions.map((submission, i) => {
-                  return (<li key={i}><strong>{submission.id.sequenceNumber}</strong>. <a href="#" onClick={() => {onDownloadClick(submission.id.sequenceNumber, filing.period)}}>Download edit report</a> - <span className="text-gray">started on {moment(submission.start).format('MMM Do, YYYY')}</span></li>)
+                  return (<li key={i}><strong>{submission.id.sequenceNumber}</strong>. <a href="#" onClick={() => {this.props.onDownloadClick(institution.id, submission.id.sequenceNumber, filing.period)}}>Download edit report</a> - <span className="text-gray">started on {moment(submission.start).format('MMM Do, YYYY')}</span></li>)
                 })}
               </ul>
             </div>

--- a/src/js/components/Institutions.jsx
+++ b/src/js/components/Institutions.jsx
@@ -87,7 +87,7 @@ const renderButton = (code, institutionId, period) => {
 
 const renderRefile = (makeNewSubmission, code, institutionId, period) => {
   if(code === 1) return null
-  return <a className="usa-button usa-button-secondary usa-text-small" onClick={()=>{    makeNewSubmission(institutionId, period)}}>Refile</a>
+  return <a className="usa-button usa-button-secondary usa-text-small" onClick={()=>{makeNewSubmission(institutionId, period)}}>Refile</a>
 }
 
 const getInstitutionFromFiling = (institutions, filing) => {
@@ -118,7 +118,7 @@ export default class Institution extends Component {
               <h5>Previous submissions for this filing</h5>
               <ul className="usa-text-small usa-unstyled-list">
                 {filingObj.submissions.map((submission, i) => {
-                  return (<li key={i}><strong>{submission.id.sequenceNumber}</strong>. <a href="#">Download edit report</a> - <span className="text-gray">started on {moment(submission.start).format('MMM Do, YYYY')}</span></li>)
+                  return (<li key={i}><strong>{submission.id.sequenceNumber}</strong>. <a href="#" onClick={() => {onDownloadClick(submission.id.sequenceNumber, filing.period)}}>Download edit report</a> - <span className="text-gray">started on {moment(submission.start).format('MMM Do, YYYY')}</span></li>)
                 })}
               </ul>
             </div>
@@ -146,5 +146,6 @@ Institution.propTypes = {
   filings: PropTypes.array,
   user: PropTypes.object,
   institutions: PropTypes.array,
-  fetchNewSubmission: PropTypes.func
+  makeNewSubmission: PropTypes.func,
+  onDownloadClick: PropTypes.func
 }

--- a/src/js/containers/EditsTable.jsx
+++ b/src/js/containers/EditsTable.jsx
@@ -2,19 +2,13 @@ import React from 'react'
 
 import EditsTableRow from '../components/EditsTableRow.jsx'
 
-const rowForEachLarTypes = ['syntactical', 'validity', 'quality']
-
-const rowForEachLar = (val) => rowForEachLarTypes.indexOf(val) !== -1
-
 const renderHeader = (props) => {
-  let row = props.lars ? props.lars[0] : props.data[0]
-  if (rowForEachLar(props.type)) row = row.lar
-
+  let row = (props.type !== 'macro') ? props.edits.rows[0].row : props.edits[0]
   return (
     <tr>
       {
         Object.keys(row).map((header, i) => {
-          if(header === 'loanId') header = 'Row ID'
+          if(header === 'rowId') header = 'Row ID'
           if(header === 'edit') header = 'Edit ID'
           if(header === 'justifications') header = 'Justifications'
           return <th key={i}>{header}</th>
@@ -24,45 +18,31 @@ const renderHeader = (props) => {
   )
 }
 
-const renderTS = (ts) => {
-  if (ts) {
-    return (
-      <tr>
-        <td>Transmittal Sheet</td>
-      </tr>
-    )
-  }
-}
-
 const renderBody = (props) => {
-  // if there is no props.lars (macro)
-  if (!props.lars) {
-    return props.data.map((macro, i) => {
+  if (props.type === 'macro') {
+    return props.edits.map((macro, i) => {
       return <EditsTableRow row={macro} key={i}/>
     })
   }
-  return props.lars.map((row, i) => {
-    if(row.lar) row = row.lar
-    return <EditsTableRow row={row} key={i}/>
+  return props.edits.rows.map((row, i) => {
+    return <EditsTableRow row={row.row} key={i}/>
   })
 }
 
 const EditsTable = (props) => {
-  let editCount = !props.lars ? props.data.length : props.lars.length
-  editCount = props.ts ? (editCount + 1) : (editCount)
-
+  const edits = props.edits
+  const { edit, description } = props.edits
   return (
     <div className="EditsTable bg-color-white">
       <table width="100%" className="margin-top-1">
         <caption>
-          <h3>{props.label ? `${props.label} - ${editCount}`: null}</h3>
-          <p>{props.desc? `${props.desc}`: null}</p>
+          <h3>{edit ? `${edit} - ${length}`: null}</h3>
+          <p>{description ? `${description}`: null}</p>
         </caption>
         <thead>
           {renderHeader(props)}
         </thead>
         <tbody>
-          {renderTS(props.ts)}
           {renderBody(props)}
         </tbody>
       </table>

--- a/src/js/containers/EditsTable.jsx
+++ b/src/js/containers/EditsTable.jsx
@@ -50,4 +50,8 @@ const EditsTable = (props) => {
   )
 }
 
+EditsTable.defaultProps = {
+  edits: []
+}
+
 export default EditsTable

--- a/src/js/containers/EditsTable.jsx
+++ b/src/js/containers/EditsTable.jsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { PropTypes } from 'react'
 
 import EditsTableRow from '../components/EditsTableRow.jsx'
 
@@ -48,6 +48,11 @@ const EditsTable = (props) => {
       </table>
     </div>
   )
+}
+
+EditsTable.propTypes = {
+  edits: PropTypes.array,
+  type: PropTypes.string
 }
 
 EditsTable.defaultProps = {

--- a/src/js/containers/Institutions.jsx
+++ b/src/js/containers/Institutions.jsx
@@ -45,14 +45,19 @@ function mapStateToProps(state) {
   }
 }
 
-function mapDispatchToProps(dispatch){
-  const makeNewSubmission = (id, period) => {
-    return dispatch(createNewSubmission(id, period)).then(()=>{
-      browserHistory.push(`/${id}/${period}`)
-    })
+function mapDispatchToProps(dispatch) {
+  return {
+    makeNewSubmission = (id, period) => {
+      return dispatch(createNewSubmission(id, period)).then(()=>{
+        browserHistory.push(`/${id}/${period}`)
+      })
+    },
+    // triggered by a click on "Download edit report"
+    onDownloadClick = (id, period) => {
+      dispatch(requestCSV(id, period))
+    },
+    dispatch
   }
-
-  return { makeNewSubmission, dispatch }
 }
 
 InstitutionContainer.defaultProps = {

--- a/src/js/containers/Institutions.jsx
+++ b/src/js/containers/Institutions.jsx
@@ -1,7 +1,7 @@
 import React, { Component } from 'react'
 import { connect } from 'react-redux'
 import { browserHistory } from 'react-router'
-import { updateFilingPeriod, fetchInstitutions, createNewSubmission } from '../actions'
+import { updateFilingPeriod, fetchInstitutions, createNewSubmission, requestCSV } from '../actions'
 import Institutions from '../components/Institutions.jsx'
 
 class InstitutionContainer extends Component {
@@ -47,14 +47,14 @@ function mapStateToProps(state) {
 
 function mapDispatchToProps(dispatch) {
   return {
-    makeNewSubmission = (id, period) => {
+    makeNewSubmission: (id, period) => {
       return dispatch(createNewSubmission(id, period)).then(()=>{
         browserHistory.push(`/${id}/${period}`)
       })
     },
     // triggered by a click on "Download edit report"
-    onDownloadClick = (id, period) => {
-      dispatch(requestCSV(id, period))
+    onDownloadClick: (institutionId, submissionId, period) => {
+      dispatch(requestCSV(institutionId, submissionId, period))
     },
     dispatch
   }


### PR DESCRIPTION
~~__WIP - failing tests but wanted to have you look at a few things first ... see below__~~

Closes #308 and closes #280 

- allows for csv download on institutions listing page
  - would really like you to check out the changes to `api.js`, it feels a bit off
  - and there's a lot of arguments being passed around through the `institutions` container and component to get there

Also

- due to changes in https://github.com/cfpb/hmda-platform/pull/760 updates how tables, rows, and cells are rendered for edits
  - and cleans it up a bit to use the `type` instead of looking at the `object` to determine what to render