### PR TITLE
Header

### DIFF
--- a/__tests__/components/Institutions.js
+++ b/__tests__/components/Institutions.js
@@ -13,7 +13,11 @@ const institutionsJSON = JSON.parse(fs.readFileSync('./__tests__/json/institutio
 describe('Institutions', () => {
   const institutions = TestUtils.renderIntoDocument(
     <Wrapper>
-      <Institutions institutions={institutionsJSON.institutions} filings={[filingJSON]} user={{profile: {name: "someone"}}}/>
+      <Institutions
+        institutions={institutionsJSON.institutions}
+        filings={[filingJSON]}
+        user={{profile: {name: "someone"}}}
+        location={{pathname: '/institutions'}} />
     </Wrapper>
   )
   const institutionsNode = ReactDOM.findDOMNode(institutions)
@@ -43,6 +47,6 @@ describe('Institutions', () => {
   })
 
   it('creates the correct number of previous submissions', () => {
-    expect(TestUtils.scryRenderedDOMComponentsWithTag(institutions, 'li').length).toEqual(4)
+    expect(TestUtils.scryRenderedDOMComponentsWithClass(institutions, 'edit-report').length).toEqual(4)
   })
 })

--- a/src/js/components/Home.jsx
+++ b/src/js/components/Home.jsx
@@ -8,23 +8,11 @@ const Home = (props) => {
 
   return (
     <div className="Home">
-      <header className="usa-header usa-header-extended" role="banner">
-        <div className="usa-banner">
-          <header className="usa-banner-header">
-            <div className="usa-grid usa-banner-inner">
-              <img src="/img/favicons/favicon-57.png" alt="U.S. flag" />
-              <p>An official website of the United States government</p>
-            </div>
-          </header>
-        </div>
-        <div className="usa-navbar">
-          <div className="usa-logo" id="logo">
-            <img src="/img/ffiec-logo.png" width="150px"/>
-          </div>
-        </div>
-        <NavHeader page={page} base={base}/>
-      </header>
-      <div id="main-content" className="usa-grid-full">
+      <NavHeader
+        page={page}
+        base={base}
+        userName={props.user.profile.name} />
+      <div id="main-content" className="usa-grid">
         <div className="usa-width-one-whole">
           <h2>Welcome to HMDA Filing{props.user.profile.name ? ' ' + props.user.profile.name : ''}</h2>
           <a href="#" onClick={props.viewInstitutions}>View Institutions</a>

--- a/src/js/components/Home.jsx
+++ b/src/js/components/Home.jsx
@@ -1,10 +1,35 @@
 import React from 'react'
+import NavHeader from '../components/NavHeader.jsx'
 
 const Home = (props) => {
+  const pathname = props.location.pathname
+  const base = pathname.split('/').slice(0,-1).join('/')
+  const page = pathname.split('/').slice(-1)[0]
+
   return (
     <div className="Home">
-      <h2>Welcome to HMDA Filing{props.user.profile.name ? ' ' + props.user.profile.name : ''}</h2>
-      <a href="#" onClick={props.viewInstitutions}>View Institutions</a>
+      <header className="usa-header usa-header-extended" role="banner">
+        <div className="usa-banner">
+          <header className="usa-banner-header">
+            <div className="usa-grid usa-banner-inner">
+              <img src="/img/favicons/favicon-57.png" alt="U.S. flag" />
+              <p>An official website of the United States government</p>
+            </div>
+          </header>
+        </div>
+        <div className="usa-navbar">
+          <div className="usa-logo" id="logo">
+            <img src="/img/ffiec-logo.png" width="150px"/>
+          </div>
+        </div>
+        <NavHeader page={page} base={base}/>
+      </header>
+      <div id="main-content" className="usa-grid-full">
+        <div className="usa-width-one-whole">
+          <h2>Welcome to HMDA Filing{props.user.profile.name ? ' ' + props.user.profile.name : ''}</h2>
+          <a href="#" onClick={props.viewInstitutions}>View Institutions</a>
+        </div>
+      </div>
     </div>
   )
 }

--- a/src/js/components/Home.jsx
+++ b/src/js/components/Home.jsx
@@ -2,20 +2,14 @@ import React from 'react'
 import NavHeader from '../components/NavHeader.jsx'
 
 const Home = (props) => {
-  const pathname = props.location.pathname
-  const base = pathname.split('/').slice(0,-1).join('/')
-  const page = pathname.split('/').slice(-1)[0]
-
   return (
     <div className="Home">
       <NavHeader
-        page={page}
-        base={base}
+        pathname={props.location.pathname}
         userName={props.user.profile.name} />
       <div id="main-content" className="usa-grid">
         <div className="usa-width-one-whole">
           <h2>Welcome to HMDA Filing{props.user.profile.name ? ' ' + props.user.profile.name : ''}</h2>
-          <a href="#" onClick={props.viewInstitutions}>View Institutions</a>
         </div>
       </div>
     </div>

--- a/src/js/components/Institutions.jsx
+++ b/src/js/components/Institutions.jsx
@@ -100,16 +100,12 @@ const getInstitutionFromFiling = (institutions, filing) => {
 
 export default class Institution extends Component {
   render() {
-    const pathname = this.props.location.pathname
-    const base = pathname.split('/').slice(0,-1).join('/')
-    const page = pathname.split('/').slice(-1)[0]
     const institutions = this.props.institutions
     const makeNewSubmission = this.props.makeNewSubmission
     return (
     <div className="Institutions">
       <NavHeader
-        page={page}
-        base={base}
+        pathname={this.props.location.pathname}
         userName={this.props.user.profile.name} />
       <div id="main-content" className="usa-grid">
         <UserHeading period="2017" userName={this.props.user.profile.name} />

--- a/src/js/components/Institutions.jsx
+++ b/src/js/components/Institutions.jsx
@@ -1,6 +1,7 @@
 import React, {Component, PropTypes} from 'react'
 import {Link} from 'react-router'
 import UserHeading from '../components/UserHeading.jsx'
+import NavHeader from '../components/NavHeader.jsx'
 import moment from 'moment'
 
 const renderTiming = (status, start, end) => {
@@ -99,36 +100,57 @@ const getInstitutionFromFiling = (institutions, filing) => {
 
 export default class Institution extends Component {
   render() {
+    const pathname = this.props.location.pathname
+    const base = pathname.split('/').slice(0,-1).join('/')
+    const page = pathname.split('/').slice(-1)[0]
     const institutions = this.props.institutions
     const makeNewSubmission = this.props.makeNewSubmission
     return (
-    <div className="Institutions usa-grid-full">
-      <UserHeading period="2017" userName={this.props.user.profile.name} />
-      <div className="usa-width-two-thirds">
-        {this.props.filings.map((filingObj, i) => {
-          const filing = filingObj.filing
-          const institution = getInstitutionFromFiling(institutions, filing)
-          return (
-            <div key={i} className="usa-grid-full institution bg-color-hmda-gray padding-2">
-              <h2>{institution.name} - {institution.id}</h2>
-              {renderTiming(filing.status, filing.start, filing.end)}
-              {renderStatus(filing.status.code, institution.name, filing.institutionId, filing.period)}
-              {renderButton(filing.status.code, filing.institutionId, filing.period)}
-              {renderRefile(makeNewSubmission, filing.status.code, filing.institutionId, filing.period)}
-              <h5>Previous submissions for this filing</h5>
-              <ul className="usa-text-small usa-unstyled-list">
-                {filingObj.submissions.map((submission, i) => {
-                  return (<li key={i}><strong>{submission.id.sequenceNumber}</strong>. <a href="#" onClick={() => {this.props.onDownloadClick(institution.id, submission.id.sequenceNumber, filing.period)}}>Download edit report</a> - <span className="text-gray">started on {moment(submission.start).format('MMM Do, YYYY')}</span></li>)
-                })}
-              </ul>
+    <div className="Institutions">
+      <header className="usa-header usa-header-extended" role="banner">
+        <div className="usa-banner">
+          <header className="usa-banner-header">
+            <div className="usa-grid usa-banner-inner">
+              <img src="/img/favicons/favicon-57.png" alt="U.S. flag" />
+              <p>An official website of the United States government</p>
             </div>
-          )
-        })}
-      </div>
-      <div className="usa-width-one-third padding-left-1 padding-right-1">
-        <p>We can use this area as some help text and talk about the process or whatever else we need to mention.</p>
-        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi nec auctor nisl. Nam ut justo nec ligula aliquam pretium et at orci. Nulla pulvinar feugiat tellus, in sagittis sem sollicitudin at. Nunc nec libero at elit consectetur elementum eu at nisl.</p>
-        <p>Curabitur molestie felis massa, vel semper nulla maximus nec. Quisque feugiat nulla nec urna tristique varius. Ut vulputate felis mi, non elementum lacus tempor ut. Etiam tempus porta arcu non venenatis. Vivamus nec tellus eleifend, pulvinar sapien sed, posuere leo.</p>
+          </header>
+        </div>
+        <div className="usa-navbar">
+          <div className="usa-logo" id="logo">
+            <img src="/img/ffiec-logo.png" width="150px"/>
+          </div>
+        </div>
+        <NavHeader page={page} base={base}/>
+      </header>
+      <div id="main-content" className="usa-grid-full">
+        <UserHeading period="2017" userName={this.props.user.profile.name} />
+        <div className="usa-width-two-thirds">
+          {this.props.filings.map((filingObj, i) => {
+            const filing = filingObj.filing
+            const institution = getInstitutionFromFiling(institutions, filing)
+            return (
+              <div key={i} className="usa-grid-full institution bg-color-hmda-gray padding-2">
+                <h2>{institution.name} - {institution.id}</h2>
+                {renderTiming(filing.status, filing.start, filing.end)}
+                {renderStatus(filing.status.code, institution.name, filing.institutionId, filing.period)}
+                {renderButton(filing.status.code, filing.institutionId, filing.period)}
+                {renderRefile(makeNewSubmission, filing.status.code, filing.institutionId, filing.period)}
+                <h5>Previous submissions for this filing</h5>
+                <ul className="usa-text-small usa-unstyled-list">
+                  {filingObj.submissions.map((submission, i) => {
+                    return (<li key={i}><strong>{submission.id.sequenceNumber}</strong>. <a href="#" onClick={() => {this.props.onDownloadClick(institution.id, submission.id.sequenceNumber, filing.period)}}>Download edit report</a> - <span className="text-gray">started on {moment(submission.start).format('MMM Do, YYYY')}</span></li>)
+                  })}
+                </ul>
+              </div>
+            )
+          })}
+        </div>
+        <div className="usa-width-one-third padding-left-1 padding-right-1">
+          <p>We can use this area as some help text and talk about the process or whatever else we need to mention.</p>
+          <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi nec auctor nisl. Nam ut justo nec ligula aliquam pretium et at orci. Nulla pulvinar feugiat tellus, in sagittis sem sollicitudin at. Nunc nec libero at elit consectetur elementum eu at nisl.</p>
+          <p>Curabitur molestie felis massa, vel semper nulla maximus nec. Quisque feugiat nulla nec urna tristique varius. Ut vulputate felis mi, non elementum lacus tempor ut. Etiam tempus porta arcu non venenatis. Vivamus nec tellus eleifend, pulvinar sapien sed, posuere leo.</p>
+        </div>
       </div>
     </div>
     )

--- a/src/js/components/Institutions.jsx
+++ b/src/js/components/Institutions.jsx
@@ -107,23 +107,11 @@ export default class Institution extends Component {
     const makeNewSubmission = this.props.makeNewSubmission
     return (
     <div className="Institutions">
-      <header className="usa-header usa-header-extended" role="banner">
-        <div className="usa-banner">
-          <header className="usa-banner-header">
-            <div className="usa-grid usa-banner-inner">
-              <img src="/img/favicons/favicon-57.png" alt="U.S. flag" />
-              <p>An official website of the United States government</p>
-            </div>
-          </header>
-        </div>
-        <div className="usa-navbar">
-          <div className="usa-logo" id="logo">
-            <img src="/img/ffiec-logo.png" width="150px"/>
-          </div>
-        </div>
-        <NavHeader page={page} base={base}/>
-      </header>
-      <div id="main-content" className="usa-grid-full">
+      <NavHeader
+        page={page}
+        base={base}
+        userName={this.props.user.profile.name} />
+      <div id="main-content" className="usa-grid">
         <UserHeading period="2017" userName={this.props.user.profile.name} />
         <div className="usa-width-two-thirds">
           {this.props.filings.map((filingObj, i) => {
@@ -139,7 +127,7 @@ export default class Institution extends Component {
                 <h5>Previous submissions for this filing</h5>
                 <ul className="usa-text-small usa-unstyled-list">
                   {filingObj.submissions.map((submission, i) => {
-                    return (<li key={i}><strong>{submission.id.sequenceNumber}</strong>. <a href="#" onClick={() => {this.props.onDownloadClick(institution.id, submission.id.sequenceNumber, filing.period)}}>Download edit report</a> - <span className="text-gray">started on {moment(submission.start).format('MMM Do, YYYY')}</span></li>)
+                    return (<li className="edit-report" key={i}><strong>{submission.id.sequenceNumber}</strong>. <a href="#" onClick={() => {this.props.onDownloadClick(institution.id, submission.id.sequenceNumber, filing.period)}}>Download edit report</a> - <span className="text-gray">started on {moment(submission.start).format('MMM Do, YYYY')}</span></li>)
                   })}
                 </ul>
               </div>

--- a/src/js/components/NavHeader.jsx
+++ b/src/js/components/NavHeader.jsx
@@ -7,19 +7,32 @@ const styleSelectedPage = (selected, current) => {
 }
 
 const NavHeader = (props) => {
-  console.log(props.page, props.base)
   return (
-    <ul className="NavHeader">
-      <li>
-        <Link style={styleSelectedPage(props.page, 'upload')} to={props.base + '/upload'}>Upload</Link>
-      </li>
-      <li>
-        <Link style={styleSelectedPage(props.page, 'edits')} to={props.base + '/edits'}>Edits</Link>
-      </li>
-      <li>
-        <Link style={styleSelectedPage(props.page, 'summary')} to={props.base + '/summary'}>Summary</Link>
-      </li>
-    </ul>
+    <nav role="navigation" className="NavHeader usa-nav">
+      <div className="usa-nav-inner">
+        <ul className="usa-nav-primary">
+          <li>
+            <Link className="usa-nav-link" style={styleSelectedPage(props.page, 'upload')} to={props.base + '/upload'}>Upload</Link>
+          </li>
+          <li>
+            <Link className="usa-nav-link" style={styleSelectedPage(props.page, 'edits')} to={props.base + '/edits'}>Edits</Link>
+          </li>
+          <li>
+            <Link className="usa-nav-link" style={styleSelectedPage(props.page, 'summary')} to={props.base + '/summary'}>Summary</Link>
+          </li>
+        </ul>
+        <div className="usa-nav-secondary">
+          <ul className="usa-unstyled-list usa-nav-secondary-links">
+            <li>
+              <Link className="usa-nav-link" style={styleSelectedPage(props.page, 'upload')} to={'/'}>Home</Link>
+            </li>
+            <li>
+              <a href="#">Logout</a>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </nav>
   )
 }
 

--- a/src/js/components/NavHeader.jsx
+++ b/src/js/components/NavHeader.jsx
@@ -1,6 +1,26 @@
 import React, { PropTypes } from 'react'
 import { Link } from 'react-router'
 
+const noEditsNav = ['', 'institutions']
+
+const renderEditsNav = (page, base) => {
+  if(noEditsNav.indexOf(page) === -1) return (
+    <ul className="usa-nav-primary">
+      <li>
+        <Link className="usa-nav-link" style={styleSelectedPage(page, 'upload')} to={base + '/upload'}>Upload</Link>
+      </li>
+      <li>
+        <Link className="usa-nav-link" style={styleSelectedPage(page, 'edits')} to={base + '/edits'}>Edits</Link>
+      </li>
+      <li>
+        <Link className="usa-nav-link" style={styleSelectedPage(page, 'summary')} to={base + '/summary'}>Summary</Link>
+      </li>
+    </ul>
+  )
+
+  return null
+}
+
 const styleSelectedPage = (selected, current) => {
   if(selected === current) return {textDecoration: 'underline'}
   return {textDecoration: 'none'}
@@ -8,37 +28,46 @@ const styleSelectedPage = (selected, current) => {
 
 const NavHeader = (props) => {
   return (
-    <nav role="navigation" className="NavHeader usa-nav">
-      <div className="usa-nav-inner">
-        <ul className="usa-nav-primary">
-          <li>
-            <Link className="usa-nav-link" style={styleSelectedPage(props.page, 'upload')} to={props.base + '/upload'}>Upload</Link>
-          </li>
-          <li>
-            <Link className="usa-nav-link" style={styleSelectedPage(props.page, 'edits')} to={props.base + '/edits'}>Edits</Link>
-          </li>
-          <li>
-            <Link className="usa-nav-link" style={styleSelectedPage(props.page, 'summary')} to={props.base + '/summary'}>Summary</Link>
-          </li>
-        </ul>
-        <div className="usa-nav-secondary">
-          <ul className="usa-unstyled-list usa-nav-secondary-links">
-            <li>
-              <Link className="usa-nav-link" style={styleSelectedPage(props.page, 'upload')} to={'/'}>Home</Link>
-            </li>
-            <li>
-              <a href="#">Logout</a>
-            </li>
-          </ul>
+    <header className="usa-header usa-header-extended" role="banner">
+      <div className="usa-banner">
+        <header className="usa-banner-header">
+          <div className="usa-grid usa-banner-inner">
+            <img src="/img/favicons/favicon-57.png" alt="U.S. flag" />
+            <p>An official website of the United States government</p>
+          </div>
+        </header>
+      </div>
+      <div className="usa-navbar">
+        <div className="usa-logo" id="logo">
+          <img src="/img/ffiec-logo.png" width="150px"/>
         </div>
       </div>
-    </nav>
+      <nav role="navigation" className="NavHeader usa-nav">
+        <div className="usa-nav-inner">
+          {renderEditsNav(props.page, props.base)}
+          <div className="usa-nav-secondary">
+            <ul className="usa-unstyled-list usa-nav-secondary-links">
+              <li>
+                <Link className="usa-nav-link" style={styleSelectedPage(props.page, '')} to={'/'}>Home</Link>
+              </li>
+              <li>
+                <Link className="usa-nav-link" style={styleSelectedPage(props.page, 'institutions')} to={'/institutions'}>Institutions</Link>
+              </li>
+              <li>
+                {props.userName} <a href="#">Logout</a>
+              </li>
+            </ul>
+          </div>
+        </div>
+      </nav>
+    </header>
   )
 }
 
 NavHeader.propTypes = {
   page: React.PropTypes.string,
-  base: React.PropTypes.string
+  base: React.PropTypes.string,
+  userName: React.PropTypes.string
 }
 
 export default NavHeader

--- a/src/js/components/NavHeader.jsx
+++ b/src/js/components/NavHeader.jsx
@@ -27,6 +27,9 @@ const styleSelectedPage = (selected, current) => {
 }
 
 const NavHeader = (props) => {
+  const base = props.pathname.split('/').slice(0,-1).join('/')
+  const page = props.pathname.split('/').slice(-1)[0]
+
   return (
     <header className="usa-header usa-header-extended" role="banner">
       <div className="usa-banner">
@@ -44,14 +47,14 @@ const NavHeader = (props) => {
       </div>
       <nav role="navigation" className="NavHeader usa-nav">
         <div className="usa-nav-inner">
-          {renderEditsNav(props.page, props.base)}
+          {renderEditsNav(page, base)}
           <div className="usa-nav-secondary">
             <ul className="usa-unstyled-list usa-nav-secondary-links">
               <li>
-                <Link className="usa-nav-link" style={styleSelectedPage(props.page, '')} to={'/'}>Home</Link>
+                <Link className="usa-nav-link" style={styleSelectedPage(page, '')} to={'/'}>Home</Link>
               </li>
               <li>
-                <Link className="usa-nav-link" style={styleSelectedPage(props.page, 'institutions')} to={'/institutions'}>Institutions</Link>
+                <Link className="usa-nav-link" style={styleSelectedPage(page, 'institutions')} to={'/institutions'}>Institutions</Link>
               </li>
               <li>
                 {props.userName} <a href="#">Logout</a>
@@ -65,9 +68,8 @@ const NavHeader = (props) => {
 }
 
 NavHeader.propTypes = {
-  page: React.PropTypes.string,
-  base: React.PropTypes.string,
-  userName: React.PropTypes.string
+  userName: React.PropTypes.string,
+  pathname: React.PropTypes.string
 }
 
 export default NavHeader

--- a/src/js/containers/App.jsx
+++ b/src/js/containers/App.jsx
@@ -2,7 +2,6 @@ import React, { Component } from 'react'
 import { connect } from 'react-redux'
 import { browserHistory } from 'react-router'
 import LoginContainer from './Login.jsx'
-import HomeLink from '../components/HomeLink.jsx'
 import { signinRedirect } from '../redirect'
 
 class AppContainer extends Component {
@@ -17,15 +16,8 @@ class AppContainer extends Component {
   render() {
     return (
       <div className="AppContainer">
-        <div className="bg-color-hmda-gray padding-1">
-          <div className="usa-grid">
-            <img src="/img/ffiec-logo.png" width="150px"/><br />
-            <HomeLink/>
-          </div>
-        </div>
-        <div className="usa-grid">
-          {this.props.children}
-        </div>
+        <a className="usa-skipnav" href="#main-content">Skip to main content</a>
+        {this.props.children}
       </div>
     )
   }

--- a/src/js/containers/Submission.jsx
+++ b/src/js/containers/Submission.jsx
@@ -81,8 +81,7 @@ class SubmissionContainer extends Component {
     return (
     <div className="SubmissionContainer">
       <NavHeader
-          page={page}
-          base={base}
+          pathname={this.props.location.pathname}
           userName={this.props.user.profile.name} />
       <div id="main-content" className="usa-grid">
         <UserHeading

--- a/src/js/containers/Submission.jsx
+++ b/src/js/containers/Submission.jsx
@@ -2,6 +2,7 @@ import React, { Component, PropTypes } from 'react'
 import { Link } from 'react-router'
 import { connect } from 'react-redux'
 import { fetchSubmission } from '../actions'
+import HomeLink from '../components/HomeLink.jsx'
 import NavHeader from '../components/NavHeader.jsx'
 import UserHeading from '../components/UserHeading.jsx'
 import UploadForm from './UploadForm.jsx'
@@ -45,7 +46,6 @@ class SubmissionContainer extends Component {
     const base = pathname.split('/').slice(0,-1).join('/')
     const page = pathname.split('/').slice(-1)[0]
     const toRender = []
-    console.log('current status code, from submission container', code)
 
     // status codes can be found at https://github.com/cfpb/hmda-platform/blob/master/Documents/submission-status.md
     if(code === -1) {
@@ -78,13 +78,26 @@ class SubmissionContainer extends Component {
       toRender.push(<p>Something is wrong, please <Link to='/institutions'>Go Back</Link></p>)
     }
 
-    console.log(toRender)
-
     return (
     <div className="SubmissionContainer">
-      <NavHeader page={page} base={base}/>
+      <header className="usa-header usa-header-extended" role="banner">
+        <div className="usa-banner">
+          <header className="usa-banner-header">
+            <div className="usa-grid usa-banner-inner">
+              <img src="/img/favicons/favicon-57.png" alt="U.S. flag" />
+              <p>An official website of the United States government</p>
+            </div>
+          </header>
+        </div>
+        <div className="usa-navbar">
+          <div className="usa-logo" id="logo">
+            <img src="/img/ffiec-logo.png" width="150px"/>
+          </div>
+        </div>
+        <NavHeader page={page} base={base}/>
+      </header>
       <UserHeading period={this.props.params.filing} userName={this.props.user.profile.name} institution={this.props.params.institution} />
-      <div className="usa-grid-full">
+      <div id="main-content" className="usa-grid-full">
         <div className="usa-width-one-whole">
           {toRender.map((component, i) => {
             return <div key={i}>{component}</div>
@@ -97,7 +110,6 @@ class SubmissionContainer extends Component {
 }
 
 function mapStateToProps(state) {
-  console.log('submission container state', state)
   const {
     isFetching,
     status

--- a/src/js/containers/Submission.jsx
+++ b/src/js/containers/Submission.jsx
@@ -80,24 +80,15 @@ class SubmissionContainer extends Component {
 
     return (
     <div className="SubmissionContainer">
-      <header className="usa-header usa-header-extended" role="banner">
-        <div className="usa-banner">
-          <header className="usa-banner-header">
-            <div className="usa-grid usa-banner-inner">
-              <img src="/img/favicons/favicon-57.png" alt="U.S. flag" />
-              <p>An official website of the United States government</p>
-            </div>
-          </header>
-        </div>
-        <div className="usa-navbar">
-          <div className="usa-logo" id="logo">
-            <img src="/img/ffiec-logo.png" width="150px"/>
-          </div>
-        </div>
-        <NavHeader page={page} base={base}/>
-      </header>
-      <UserHeading period={this.props.params.filing} userName={this.props.user.profile.name} institution={this.props.params.institution} />
-      <div id="main-content" className="usa-grid-full">
+      <NavHeader
+          page={page}
+          base={base}
+          userName={this.props.user.profile.name} />
+      <div id="main-content" className="usa-grid">
+        <UserHeading
+          period={this.props.params.filing}
+          userName={this.props.user.profile.name}
+          institution={this.props.params.institution} />
         <div className="usa-width-one-whole">
           {toRender.map((component, i) => {
             return <div key={i}>{component}</div>

--- a/src/sass/app.scss
+++ b/src/sass/app.scss
@@ -31,6 +31,10 @@ h6,
   font-family: "Source Sans Pro", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
 }
 
+.usa-header {
+  margin-bottom: 3em;
+}
+
 .usa-logo {
   line-height: 0;
 }

--- a/src/sass/app.scss
+++ b/src/sass/app.scss
@@ -31,6 +31,20 @@ h6,
   font-family: "Source Sans Pro", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
 }
 
+.usa-logo {
+  line-height: 0;
+}
+
+.usa-nav-secondary-links {
+  li {
+    &:not(:last-child)::after {
+      @include media($nav-width) {
+        content: none;
+      }
+    }
+  }
+}
+
 a {
  cursor: pointer;
 }


### PR DESCRIPTION
Closes #230

- adds in a better header (based on [USWDS](https://standards.usa.gov/headers/#extended))
- renders the submission part of the nav only when needed
- adds username and logout to the header
- minor styling updates

---

### Without submission nav
![header-no-edits](https://cloud.githubusercontent.com/assets/2932572/21855684/483bc496-d7ed-11e6-9ef4-024c7eb76633.png)

---

### With submission nav
![header-with-edits](https://cloud.githubusercontent.com/assets/2932572/21855693/4fd27b28-d7ed-11e6-8156-89c6ddd32819.png)

---

Still do to:
- what do we do for the logout link? (#315)
- needs better styling (#314)