### PR TITLE
Edits csv download

### DIFF
--- a/__tests__/components/EditsHeaderDescription.js
+++ b/__tests__/components/EditsHeaderDescription.js
@@ -22,7 +22,7 @@ describe('EditsHeaderDescription', function(){
   })
 
   it('correctly sets the syntactical desc', function(){
-    expect(headerNode.textContent).toEqual('Syntactical Edits - 1Edits that check whether the loan/application register is in the correct format and whether the data covers the correct filing year. The loan/application register cannot be filed until the filer corrects all syntactical edit errors and reuploads the updated loan/application register to the HMDA Platform.')
+    expect(headerNode.textContent).toEqual('Syntactical Edits - 1Edits that check whether the loan/application register is in the correct format and whether the data covers the correct filing year. The loan/application register cannot be filed until the filer corrects all syntactical edit errors and reuploads the updated loan/application register to the HMDA Platform.Download syntactical edits (CSV)')
   })
 
   const headerValidity = TestUtils.renderIntoDocument(
@@ -31,7 +31,7 @@ describe('EditsHeaderDescription', function(){
   const headerValidityNode = ReactDOM.findDOMNode(headerValidity)
 
   it('correctly sets the validity desc', function(){
-    expect(headerValidityNode.textContent).toEqual('Validity Edits - 1Edits that check whether there are valid values in each data field. The loan/application register cannot be filed until the filer corrects all validity edit errors and reuploads the updated loan/application register to the HMDA Platform.')
+    expect(headerValidityNode.textContent).toEqual('Validity Edits - 1Edits that check whether there are valid values in each data field. The loan/application register cannot be filed until the filer corrects all validity edit errors and reuploads the updated loan/application register to the HMDA Platform.Download validity edits (CSV)')
   })
 
   const headerQuality = TestUtils.renderIntoDocument(
@@ -40,7 +40,7 @@ describe('EditsHeaderDescription', function(){
   const headerQualityNode = ReactDOM.findDOMNode(headerQuality)
 
   it('correctly sets the Quality desc', function(){
-    expect(headerQualityNode.textContent).toEqual('Quality Edits - 1Edits that check whether entries in the individual data fields or combinations of data fields conform to expected values. The loan/application register cannot be filed until the filer either confirms the accuracy of all values flagged by quality edits in the HMDA Platform, or corrects the flagged values and reuploads the updated loan/application register to the HMDA Platform.')
+    expect(headerQualityNode.textContent).toEqual('Quality Edits - 1Edits that check whether entries in the individual data fields or combinations of data fields conform to expected values. The loan/application register cannot be filed until the filer either confirms the accuracy of all values flagged by quality edits in the HMDA Platform, or corrects the flagged values and reuploads the updated loan/application register to the HMDA Platform.Download quality edits (CSV)')
   })
 
   const headerMarcro = TestUtils.renderIntoDocument(
@@ -48,8 +48,8 @@ describe('EditsHeaderDescription', function(){
   )
   const headerMarcroNode = ReactDOM.findDOMNode(headerMarcro)
 
-  it('correctly sets the Quality desc', function(){
-    expect(headerMarcroNode.textContent).toEqual('Macro Edits - 1Edits that check whether the submitted loan/application register as a whole conforms to expected values. The loan/application register cannot be filed until the filer either confirms the accuracy of all the values flagged by the macro quality edits in the HMDA Platform or corrects the flagged values and reuploads the updated loan/application register to the HMDA Platform.')
+  it('correctly sets the Macro desc', function(){
+    expect(headerMarcroNode.textContent).toEqual('Macro Edits - 1Edits that check whether the submitted loan/application register as a whole conforms to expected values. The loan/application register cannot be filed until the filer either confirms the accuracy of all the values flagged by the macro quality edits in the HMDA Platform or corrects the flagged values and reuploads the updated loan/application register to the HMDA Platform.Download macro edits (CSV)')
   })
 
   const headerLAR = TestUtils.renderIntoDocument(
@@ -58,7 +58,7 @@ describe('EditsHeaderDescription', function(){
   const headerLARNode = ReactDOM.findDOMNode(headerLAR)
 
   it('correctly sets the LAR desc', function(){
-    expect(headerLARNode.textContent).toEqual('Loan Application Records - 1LAR refers to the loan/application register. Loan/Application Register means both the record of information required to be collected pursuant to § 1003.4 and the record submitted annually or quarterly, as applicable, pursuant to § 1003.5(a).')
+    expect(headerLARNode.textContent).toEqual('Loan Application Records - 1LAR refers to the loan/application register. Loan/Application Register means both the record of information required to be collected pursuant to § 1003.4 and the record submitted annually or quarterly, as applicable, pursuant to § 1003.5(a).Download lar edits (CSV)')
   })
 
   it('throws an error for a bad type', () => {

--- a/package.json
+++ b/package.json
@@ -71,7 +71,9 @@
     ]
   },
   "jest": {
-    "transform": { ".*": "<rootDir>/node_modules/babel-jest"},
+    "transform": {
+      ".*": "<rootDir>/node_modules/babel-jest"
+    },
     "testPathIgnorePatterns": [
       "<rootDir>/__tests__/Wrapper.js"
     ],
@@ -88,6 +90,7 @@
   },
   "dependencies": {
     "envify": "3.4.1",
+    "file-saver": "1.3.3",
     "immutable": "3.8.1",
     "jquery": "3.1.1",
     "jquery.easing": "1.4.1",

--- a/src/js/actions/index.js
+++ b/src/js/actions/index.js
@@ -16,7 +16,8 @@ import {
   getSummary,
   setAccessToken,
   getAccessToken,
-  getParseErrors
+  getParseErrors,
+  getEditsOfType
 } from '../api'
 import * as types from '../constants'
 
@@ -344,6 +345,7 @@ function detectIE() {
 }
 
 // downloading the csv edit reports, no reducer required
+// used on the institution listing
 export function requestCSV(institutionId, submissionId, period) {
   return dispatch => {
     dispatch(requestEditsByType())
@@ -355,6 +357,20 @@ export function requestCSV(institutionId, submissionId, period) {
         } else {
           var blob = new Blob([csv], {type: 'text/csv;charset=utf-8,'});
           navigator.msSaveOrOpenBlob(blob, 'edits.csv');
+        }
+      })
+  }
+}
+
+export function requestCSVByType(type) {
+  return dispatch => {
+    return getEditsOfType(latestSubmissionId, type, {format: 'csv'})
+      .then(csv => {
+        if (detectIE() === false) {
+          window.open('data:text/csv;charset=utf-8,' + encodeURIComponent(csv));
+        } else {
+          var blob = new Blob([csv], {type: 'text/csv;charset=utf-8,'});
+          navigator.msSaveOrOpenBlob(blob, `${type}.csv`);
         }
       })
   }

--- a/src/js/actions/index.js
+++ b/src/js/actions/index.js
@@ -20,6 +20,7 @@ import {
   getEditsOfType
 } from '../api'
 import * as types from '../constants'
+import fileSaver from 'file-saver'
 
 let latestSubmissionId
 let currentFilingPeriod
@@ -317,33 +318,6 @@ export function fetchParseErrors() {
   }
 }
 
-// used to trigger csv download properly
-function detectIE() {
-  const ua = window.navigator.userAgent;
-
-  const msie = ua.indexOf('MSIE ');
-  if (msie >= 0) {
-      // IE 10 or older => return version number
-      return parseInt(ua.substring(msie + 5, ua.indexOf('.', msie)), 10);
-  }
-
-  const trident = ua.indexOf('Trident/');
-  if (trident >= 0) {
-      // IE 11 => return version number
-      var rv = ua.indexOf('rv:');
-      return parseInt(ua.substring(rv + 3, ua.indexOf('.', rv)), 10);
-  }
-
-  const edge = ua.indexOf('Edge/');
-  if (edge >= 0) {
-     // IE 12 => return version number
-     return parseInt(ua.substring(edge + 5, ua.indexOf('.', edge)), 10);
-  }
-
-  // other browser
-  return false;
-}
-
 // downloading the csv edit reports, no reducer required
 // used on the institution listing
 export function requestCSV(institutionId, submissionId, period) {
@@ -352,12 +326,7 @@ export function requestCSV(institutionId, submissionId, period) {
     return getEditsByType(submissionId, institutionId, period, {format: 'csv'})
       .then(csv => {
         // trigger the download
-        if (detectIE() === false) {
-          window.open('data:text/csv;charset=utf-8,' + encodeURIComponent(csv));
-        } else {
-          var blob = new Blob([csv], {type: 'text/csv;charset=utf-8,'});
-          navigator.msSaveOrOpenBlob(blob, 'edits.csv');
-        }
+        fileSaver.saveAs(new Blob([csv], {type: 'text/csv;charset=utf-8'}), 'editreport.csv')
       })
   }
 }
@@ -366,12 +335,7 @@ export function requestCSVByType(type) {
   return dispatch => {
     return getEditsOfType(latestSubmissionId, type, {format: 'csv'})
       .then(csv => {
-        if (detectIE() === false) {
-          window.open('data:text/csv;charset=utf-8,' + encodeURIComponent(csv));
-        } else {
-          var blob = new Blob([csv], {type: 'text/csv;charset=utf-8,'});
-          navigator.msSaveOrOpenBlob(blob, `${type}.csv`);
-        }
+        fileSaver.saveAs(new Blob([csv], {type: 'text/csv;charset=utf-8'}), `${type}.csv`)
       })
   }
 }

--- a/src/js/api.js
+++ b/src/js/api.js
@@ -122,6 +122,11 @@ export function getEditsByType(submission, institutionId, period, params){
   return sendFetch(`/submissions/${submission}/edits`)
 }
 
+// fetch edits of a specific type
+export function getEditsOfType(submission, type, params = {}) {
+  return sendFetch(`/submissions/${submission}/edits/${type}`, {params:params})
+}
+
 export function getEditsByRow(submission){
   return sendFetch(`/submissions/${submission}/edits/lars`)
 }

--- a/src/js/components/EditsByType.jsx
+++ b/src/js/components/EditsByType.jsx
@@ -32,7 +32,7 @@ const EditsByType = (props) => {
         Object.keys(props.types).map((type, i) => {
           return (
             <div className="EditsContainerEntry" key={i}>
-              <EditsHeaderDescription count={props.types[type].edits.length} type={type} />
+              <EditsHeaderDescription count={props.types[type].edits.length} type={type} onDownloadClick={props.onDownloadClick} />
               <div className="border margin-bottom-5 padding-1">
                 {renderTables(props.types[type], type)}
               </div>

--- a/src/js/components/EditsHeaderDescription.jsx
+++ b/src/js/components/EditsHeaderDescription.jsx
@@ -42,7 +42,10 @@ const renderCSVLink = (props) => {
   if(props.count === 0) return null
 
   return (
-    <p><a href="javascript:void(0)" onClick={() => {props.onDownloadClick(props.type)}}>Download {props.type} edits (CSV)</a></p>
+    <p><a href="#" onClick={(e) => {
+      e.preventDefault()
+      props.onDownloadClick(props.type)
+    }}>Download {props.type} edits (CSV)</a></p>
   )
 }
 

--- a/src/js/components/EditsHeaderDescription.jsx
+++ b/src/js/components/EditsHeaderDescription.jsx
@@ -38,12 +38,21 @@ const getText = (editType) => {
   return {id, title, desc}
 }
 
+const renderCSVLink = (props) => {
+  if(props.count === 0) return null
+
+  return (
+    <p><a href="javascript:void(0)" onClick={() => {props.onDownloadClick(props.type)}}>Download {props.type} edits (CSV)</a></p>
+  )
+}
+
 const EditsHeaderDescription = (props) => {
   const textObj = getText(props.type)
   return (
     <div className="EditsHeaderDescription padding-2 bg-color-gray-lightest" id={textObj.id}>
       <h2>{textObj.title} - {props.count}</h2>
       <p className="usa-font-lead">{textObj.desc}</p>
+      {renderCSVLink(props)}
     </div>
   )
 }

--- a/src/js/components/Institutions.jsx
+++ b/src/js/components/Institutions.jsx
@@ -123,7 +123,7 @@ export default class Institution extends Component {
                 <h5>Previous submissions for this filing</h5>
                 <ul className="usa-text-small usa-unstyled-list">
                   {filingObj.submissions.map((submission, i) => {
-                    return (<li className="edit-report" key={i}><strong>{submission.id.sequenceNumber}</strong>. <a href="javascript:void(0)" onClick={() => {this.props.onDownloadClick(institution.id, submission.id.sequenceNumber, filing.period)}}>Download edit report</a> - <span className="text-gray">started on {moment(submission.start).format('MMM Do, YYYY')}</span></li>)
+                    return (<li className="edit-report" key={i}><strong>{submission.id.sequenceNumber}</strong>. <a href="#" onClick={(e) => {e.preventDefault(); this.props.onDownloadClick(institution.id, submission.id.sequenceNumber, filing.period)}}>Download edit report</a> - <span className="text-gray">started on {moment(submission.start).format('MMM Do, YYYY')}</span></li>)
                   })}
                 </ul>
               </div>

--- a/src/js/components/Institutions.jsx
+++ b/src/js/components/Institutions.jsx
@@ -123,7 +123,7 @@ export default class Institution extends Component {
                 <h5>Previous submissions for this filing</h5>
                 <ul className="usa-text-small usa-unstyled-list">
                   {filingObj.submissions.map((submission, i) => {
-                    return (<li className="edit-report" key={i}><strong>{submission.id.sequenceNumber}</strong>. <a href="#" onClick={() => {this.props.onDownloadClick(institution.id, submission.id.sequenceNumber, filing.period)}}>Download edit report</a> - <span className="text-gray">started on {moment(submission.start).format('MMM Do, YYYY')}</span></li>)
+                    return (<li className="edit-report" key={i}><strong>{submission.id.sequenceNumber}</strong>. <a href="javascript:void(0)" onClick={() => {this.props.onDownloadClick(institution.id, submission.id.sequenceNumber, filing.period)}}>Download edit report</a> - <span className="text-gray">started on {moment(submission.start).format('MMM Do, YYYY')}</span></li>)
                   })}
                 </ul>
               </div>

--- a/src/js/containers/Edits.jsx
+++ b/src/js/containers/Edits.jsx
@@ -1,6 +1,6 @@
 import React, { Component } from 'react'
 import { connect } from 'react-redux'
-import { fetchEditsByType, fetchEditsByRow } from '../actions'
+import { fetchEditsByType, fetchEditsByRow, requestCSVByType } from '../actions'
 import EditsByType from '../components/EditsByType.jsx'
 import EditsByRow from '../components/EditsByRow.jsx'
 
@@ -51,4 +51,14 @@ function mapStateToProps(state) {
   }
 }
 
-export default connect(mapStateToProps)(EditsContainer)
+function mapDispatchToProps(dispatch) {
+  return {
+    // triggered by a edit type download click
+    onDownloadClick: (type) => {
+      dispatch(requestCSVByType(type))
+    },
+    dispatch
+  }
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(EditsContainer)

--- a/src/js/containers/EditsTable.jsx
+++ b/src/js/containers/EditsTable.jsx
@@ -29,16 +29,26 @@ const renderBody = (props) => {
   })
 }
 
-const EditsTable = (props) => {
+const renderCaption = (props) => {
+  if (props.type === 'macro') return null
+
   const edits = props.edits
   const { edit, description } = props.edits
+  const length = (props.type !== 'macro') ? props.edits.rows.length : props.edits.length
+
+  return (
+    <caption>
+      <h3>{edit ? `${edit} - ${length}`: null}</h3>
+      <p>{description ? `${description}`: null}</p>
+    </caption>
+  )
+}
+
+const EditsTable = (props) => {
   return (
     <div className="EditsTable bg-color-white">
       <table width="100%" className="margin-top-1">
-        <caption>
-          <h3>{edit ? `${edit} - ${length}`: null}</h3>
-          <p>{description ? `${description}`: null}</p>
-        </caption>
+        {renderCaption(props)}
         <thead>
           {renderHeader(props)}
         </thead>


### PR DESCRIPTION
- adds in CSV download for each edit type on the `/edits` "page"
  - uses `javascript:void(0)` as the `href` (for the CSV download on the `/institutions` too) ... is there a better way?
- quick fix for edit count always saying `0`
