### PR TITLE
Edit headings

### DIFF
--- a/__tests__/components/EditsHeaderDescription.js
+++ b/__tests__/components/EditsHeaderDescription.js
@@ -22,16 +22,16 @@ describe('EditsHeaderDescription', function(){
   })
 
   it('correctly sets the syntactical desc', function(){
-    expect(headerNode.textContent).toEqual('Syntactical Edits - 1Edits that check whether the loan/application register is in the correct format and whether the data covers the correct filing year. The loan/application register cannot be filed until the filer corrects all syntactical edit errors and reuploads the updated loan/application register to the HMDA Platform.Download syntactical edits (CSV)')
+    expect(headerNode.textContent).toEqual('1 Syntactical EditEdits that check whether the loan/application register is in the correct format and whether the data covers the correct filing year. The loan/application register cannot be filed until the filer corrects all syntactical edit errors and reuploads the updated loan/application register to the HMDA Platform.Download syntactical edits (CSV)')
   })
 
   const headerValidity = TestUtils.renderIntoDocument(
-    <Wrapper><EditsHeaderDescription type="validity" count={1} /></Wrapper>
+    <Wrapper><EditsHeaderDescription type="validity" count={2} /></Wrapper>
   )
   const headerValidityNode = ReactDOM.findDOMNode(headerValidity)
 
   it('correctly sets the validity desc', function(){
-    expect(headerValidityNode.textContent).toEqual('Validity Edits - 1Edits that check whether there are valid values in each data field. The loan/application register cannot be filed until the filer corrects all validity edit errors and reuploads the updated loan/application register to the HMDA Platform.Download validity edits (CSV)')
+    expect(headerValidityNode.textContent).toEqual('2 Validity EditsEdits that check whether there are valid values in each data field. The loan/application register cannot be filed until the filer corrects all validity edit errors and reuploads the updated loan/application register to the HMDA Platform.Download validity edits (CSV)')
   })
 
   const headerQuality = TestUtils.renderIntoDocument(
@@ -40,16 +40,16 @@ describe('EditsHeaderDescription', function(){
   const headerQualityNode = ReactDOM.findDOMNode(headerQuality)
 
   it('correctly sets the Quality desc', function(){
-    expect(headerQualityNode.textContent).toEqual('Quality Edits - 1Edits that check whether entries in the individual data fields or combinations of data fields conform to expected values. The loan/application register cannot be filed until the filer either confirms the accuracy of all values flagged by quality edits in the HMDA Platform, or corrects the flagged values and reuploads the updated loan/application register to the HMDA Platform.Download quality edits (CSV)')
+    expect(headerQualityNode.textContent).toEqual('1 Quality EditEdits that check whether entries in the individual data fields or combinations of data fields conform to expected values. The loan/application register cannot be filed until the filer either confirms the accuracy of all values flagged by quality edits in the HMDA Platform, or corrects the flagged values and reuploads the updated loan/application register to the HMDA Platform.Download quality edits (CSV)')
   })
 
   const headerMarcro = TestUtils.renderIntoDocument(
-    <Wrapper><EditsHeaderDescription type="macro" count={1} /></Wrapper>
+    <Wrapper><EditsHeaderDescription type="macro" count={4} /></Wrapper>
   )
   const headerMarcroNode = ReactDOM.findDOMNode(headerMarcro)
 
   it('correctly sets the Macro desc', function(){
-    expect(headerMarcroNode.textContent).toEqual('Macro Edits - 1Edits that check whether the submitted loan/application register as a whole conforms to expected values. The loan/application register cannot be filed until the filer either confirms the accuracy of all the values flagged by the macro quality edits in the HMDA Platform or corrects the flagged values and reuploads the updated loan/application register to the HMDA Platform.Download macro edits (CSV)')
+    expect(headerMarcroNode.textContent).toEqual('4 Macro EditsEdits that check whether the submitted loan/application register as a whole conforms to expected values. The loan/application register cannot be filed until the filer either confirms the accuracy of all the values flagged by the macro quality edits in the HMDA Platform or corrects the flagged values and reuploads the updated loan/application register to the HMDA Platform.Download macro edits (CSV)')
   })
 
   const headerLAR = TestUtils.renderIntoDocument(
@@ -58,7 +58,7 @@ describe('EditsHeaderDescription', function(){
   const headerLARNode = ReactDOM.findDOMNode(headerLAR)
 
   it('correctly sets the LAR desc', function(){
-    expect(headerLARNode.textContent).toEqual('Loan Application Records - 1LAR refers to the loan/application register. Loan/Application Register means both the record of information required to be collected pursuant to § 1003.4 and the record submitted annually or quarterly, as applicable, pursuant to § 1003.5(a).Download lar edits (CSV)')
+    expect(headerLARNode.textContent).toEqual('1 Loan Application RecordLAR refers to the loan/application register. Loan/Application Register means both the record of information required to be collected pursuant to § 1003.4 and the record submitted annually or quarterly, as applicable, pursuant to § 1003.5(a).Download lar edits (CSV)')
   })
 
   it('throws an error for a bad type', () => {

--- a/__tests__/components/RefileWarning.js
+++ b/__tests__/components/RefileWarning.js
@@ -11,8 +11,8 @@ import { parseLocation } from '../../src/js/api'
 parseLocation.mockImplementation(() => { return { id:'1', period: '2017', submission: 1 } })
 
 describe('Refile Warning', () => {
-  const parserText = 'Parsing errors require file resubmission.'
-  const refileText = 'Syntactical and validity edits require file resubmission.';
+  const parserText = 'Parsing errors require file resubmission. Refile here.'
+  const refileText = 'Syntactical and validity edits require file resubmission. Refile here.';
   const validateText = 'Quality and macro edits must be validated before continuing.';
   const synTypes = {
     syntactical: {edits: [{some:'edit'}]},
@@ -48,8 +48,8 @@ describe('Refile Warning', () => {
         <RefileWarning submission={submission} types={synTypes} refileLink={refileLink}/>
       </Wrapper>
     )
-
-    expect(TestUtils.findRenderedDOMComponentWithClass(refileWarning, 'usa-alert-heading').innerHTML.match(parserText)[0]).toEqual(parserText);
+    
+    expect(TestUtils.findRenderedDOMComponentWithClass(refileWarning, 'usa-alert-text').textContent).toEqual(parserText);
     expect(TestUtils.scryRenderedDOMComponentsWithTag(refileWarning, 'a').length).toEqual(1);
 
     const link = TestUtils.findRenderedDOMComponentWithTag(refileWarning, 'a')
@@ -72,7 +72,7 @@ describe('Refile Warning', () => {
       </Wrapper>
     )
 
-    expect(TestUtils.findRenderedDOMComponentWithClass(refileWarning, 'usa-alert-heading').innerHTML.match(refileText)[0]).toEqual(refileText);
+    expect(TestUtils.findRenderedDOMComponentWithClass(refileWarning, 'usa-alert-text').textContent).toEqual(refileText);
     expect(TestUtils.scryRenderedDOMComponentsWithTag(refileWarning, 'a').length).toEqual(1);
   });
 
@@ -91,7 +91,7 @@ describe('Refile Warning', () => {
       </Wrapper>
     )
 
-    expect(TestUtils.findRenderedDOMComponentWithClass(refileWarning, 'usa-alert-heading').innerHTML.match(validateText)[0]).toEqual(validateText);
+    expect(TestUtils.findRenderedDOMComponentWithClass(refileWarning, 'usa-alert-text').textContent).toEqual(validateText);
     expect(TestUtils.scryRenderedDOMComponentsWithTag(refileWarning, 'a').length).toEqual(0);
   });
 
@@ -109,7 +109,7 @@ describe('Refile Warning', () => {
       </Wrapper>
     )
 
-    expect(TestUtils.scryRenderedDOMComponentsWithClass(refileWarning, 'usa-alert-heading').length).toEqual(0);
+    expect(TestUtils.scryRenderedDOMComponentsWithClass(refileWarning, 'usa-alert-text').length).toEqual(0);
     expect(TestUtils.scryRenderedDOMComponentsWithTag(refileWarning, 'a').length).toEqual(0);
   });
 

--- a/src/js/components/EditsHeaderDescription.jsx
+++ b/src/js/components/EditsHeaderDescription.jsx
@@ -1,6 +1,6 @@
 import React, { PropTypes } from 'react'
 
-const getText = (editType) => {
+const getText = (editType, count) => {
   let id = null
   let title = null
   let desc = null
@@ -8,27 +8,27 @@ const getText = (editType) => {
   switch (editType) {
     case 'lar':
       id = 'lar'
-      title = 'Loan Application Records'
+      title = count === 1 ? 'Loan Application Record' : 'Loan Application Records'
       desc = 'LAR refers to the loan/application register. Loan/Application Register means both the record of information required to be collected pursuant to § 1003.4 and the record submitted annually or quarterly, as applicable, pursuant to § 1003.5(a).'
       break
     case 'syntactical':
       id = 'syntactical'
-      title = 'Syntactical Edits'
+      title = count === 1 ? 'Syntactical Edit' : 'Syntactical Edits'
       desc = 'Edits that check whether the loan/application register is in the correct format and whether the data covers the correct filing year. The loan/application register cannot be filed until the filer corrects all syntactical edit errors and reuploads the updated loan/application register to the HMDA Platform.'
       break
     case 'validity':
       id = 'validity'
-      title =  'Validity Edits'
+      title = count === 1 ? 'Validity Edit' : 'Validity Edits'
       desc = 'Edits that check whether there are valid values in each data field. The loan/application register cannot be filed until the filer corrects all validity edit errors and reuploads the updated loan/application register to the HMDA Platform.'
       break
     case 'quality':
       id = 'quality'
-      title =  'Quality Edits'
+      title = count === 1 ? 'Quality Edit' : 'Quality Edits'
       desc = 'Edits that check whether entries in the individual data fields or combinations of data fields conform to expected values. The loan/application register cannot be filed until the filer either confirms the accuracy of all values flagged by quality edits in the HMDA Platform, or corrects the flagged values and reuploads the updated loan/application register to the HMDA Platform.'
       break
     case 'macro':
       id = 'macro'
-      title =  'Macro Edits'
+      title = count === 1 ? 'Macro Edit' : 'Macro Edits'
       desc = 'Edits that check whether the submitted loan/application register as a whole conforms to expected values. The loan/application register cannot be filed until the filer either confirms the accuracy of all the values flagged by the macro quality edits in the HMDA Platform or corrects the flagged values and reuploads the updated loan/application register to the HMDA Platform.'
       break
     case 'rows':
@@ -55,11 +55,14 @@ const renderCSVLink = (props) => {
 }
 
 const EditsHeaderDescription = (props) => {
-  const textObj = getText(props.type)
+  const { type, count } = props
+  const { id, title, desc } = getText(type, count)
+  const headingClass = count > 0 ? 'text-secondary' : 'text-green'
+
   return (
-    <div className="EditsHeaderDescription padding-2 bg-color-gray-lightest" id={textObj.id}>
-      <h2>{textObj.title} - {props.count}</h2>
-      <p className="usa-font-lead">{textObj.desc}</p>
+    <div className="EditsHeaderDescription" id={id}>
+      <h2 className={headingClass}>{count} {title}</h2>
+      <p className="usa-font-lead">{desc}</p>
       {renderCSVLink(props)}
     </div>
   )

--- a/src/js/components/EditsTable.jsx
+++ b/src/js/components/EditsTable.jsx
@@ -58,11 +58,13 @@ const EditsTable = (props) => {
     length = edits.edits.length
   }
 
+  const editText = length === 1 ? 'edit' : 'edits'
+
   return (
-    <div className="EditsTable bg-color-white">
+    <div className="EditsTable">
       <table width="100%" className="margin-top-1">
         <caption>
-          <h3>{name ? `${name} - ${length}`:null}</h3>
+          <h3>{name ? `${length} ${name} ${editText} found.`:null}</h3>
           <p>{description}</p>
         </caption>
         <thead>

--- a/src/js/components/EditsTableWrapper.jsx
+++ b/src/js/components/EditsTableWrapper.jsx
@@ -16,9 +16,8 @@ const renderTables = (editObj, type) => {
 
   if(edits.length === 0) {
     return (
-      <div className="usa-alert usa-alert-success margin-top-0">
+      <div className="usa-alert usa-alert-success">
         <div className="usa-alert-body">
-          <h3 className="usa-alert-heading">Success</h3>
           <p className="usa-alert-text">No <strong>{label}</strong> edits found.</p>
         </div>
       </div>
@@ -48,9 +47,7 @@ const EditsTableWrapper = (props) => {
         return (
           <div className="EditsContainerEntry" key={i}>
             <EditsHeaderDescription count={getCount(editObj[type], type)} type={type} onDownloadClick={props.onDownloadClick}/>
-            <div className="border margin-bottom-5 padding-1">
-              {renderTables(editObj[type], type)}
-            </div>
+            {renderTables(editObj[type], type)}
           </div>
         )
       })

--- a/src/js/components/ParseErrors.jsx
+++ b/src/js/components/ParseErrors.jsx
@@ -46,29 +46,29 @@ const renderTSErrors = (transmittalSheetErrors) => {
 }
 
 const ParseErrors = (props) => {
+  const count = props.transmittalSheetErrors.length + props.larErrors.length
+  const errorText = count > 1 ? 'Errors' : 'Error'
+
   return (
     <div className="ParseErrors usa-grid-full" id="parseErrors">
-      <div className="padding-2 bg-color-gray-lightest">
-        <h2 className="margin-top-0">Parsing Errors</h2>
-        <p className="usa-font-lead margin-top-half margin-bottom-0">There are errors that prevented your file from being validated. You must fix these errors and re-upload your file.</p>
+      <div className="desc">
+        <h2 className="margin-top-0 text-secondary">{count} Parsing {errorText}</h2>
+        <p className="usa-font-lead">There are errors that prevented your file from being validated. You must fix these errors and re-upload your file.</p>
       </div>
-
-      <div className="border margin-bottom-5 padding-1">
-        <table className="margin-bottom-0" width="100%">
-          <thead>
-            <tr>
-              <th>Row</th>
-              <th>Errors</th>
-            </tr>
-          </thead>
-          <tbody>
-            {renderTSErrors(props.transmittalSheetErrors)}
-            {props.larErrors.map((larError, i) => {
-              return <tr key={i}>{renderData(larError)}</tr>
-            })}
-          </tbody>
-        </table>
-      </div>
+      <table className="margin-bottom-0" width="100%">
+        <thead>
+          <tr>
+            <th>Row</th>
+            <th>Errors</th>
+          </tr>
+        </thead>
+        <tbody>
+          {renderTSErrors(props.transmittalSheetErrors)}
+          {props.larErrors.map((larError, i) => {
+            return <tr key={i}>{renderData(larError)}</tr>
+          })}
+        </tbody>
+      </table>
     </div>
   )
 }

--- a/src/js/components/RefileWarning.jsx
+++ b/src/js/components/RefileWarning.jsx
@@ -1,10 +1,6 @@
 import React, { PropTypes } from 'react'
 import { Link } from 'react-router'
 
-const parserText = ''
-const refileText = ''
-const validateText = ''
-
 const getText = (props) => {
   let textToRender = null
   let refileLink = null
@@ -12,7 +8,6 @@ const getText = (props) => {
   if(props.types.hasOwnProperty('syntactical')) {
     if(props.types.syntactical.edits.length !== 0 || props.types.validity.edits.length !== 0) {
       textToRender = <p className="usa-alert-text"><strong>Syntactical</strong> and <strong>validity</strong> edits require file resubmission. {getRefileLink(props)}</p>
-      //refileLink =
     } else {
       textToRender = <p className="usa-alert-text"><strong>Quality</strong> and <strong>macro</strong> edits must be validated before continuing.</p>
     }
@@ -20,7 +15,6 @@ const getText = (props) => {
 
   if(props.submission.status.code === 5) {
     textToRender = <p className="usa-alert-text"><strong>Parsing</strong> errors require file resubmission. {getRefileLink(props)}</p>
-    //refileLink = getRefileLink(props)
   }
 
   return (

--- a/src/js/components/RefileWarning.jsx
+++ b/src/js/components/RefileWarning.jsx
@@ -1,9 +1,9 @@
 import React, { PropTypes } from 'react'
 import { Link } from 'react-router'
 
-const parserText = 'Parsing errors require file resubmission.'
-const refileText = 'Syntactical and validity edits require file resubmission.'
-const validateText = 'Quality and macro edits must be validated before continuing.'
+const parserText = ''
+const refileText = ''
+const validateText = ''
 
 const getText = (props) => {
   let textToRender = null
@@ -11,19 +11,23 @@ const getText = (props) => {
 
   if(props.types.hasOwnProperty('syntactical')) {
     if(props.types.syntactical.edits.length !== 0 || props.types.validity.edits.length !== 0) {
-      textToRender = refileText
-      refileLink = getRefileLink(props)
+      textToRender = <p className="usa-alert-text"><strong>Syntactical</strong> and <strong>validity</strong> edits require file resubmission. {getRefileLink(props)}</p>
+      //refileLink =
     } else {
-      textToRender = validateText
+      textToRender = <p className="usa-alert-text"><strong>Quality</strong> and <strong>macro</strong> edits must be validated before continuing.</p>
     }
   }
 
   if(props.submission.status.code === 5) {
-    textToRender = parserText
-    refileLink = getRefileLink(props)
+    textToRender = <p className="usa-alert-text"><strong>Parsing</strong> errors require file resubmission. {getRefileLink(props)}</p>
+    //refileLink = getRefileLink(props)
   }
 
-  return <h3 className="usa-alert-heading">{textToRender}{refileLink?' ':''}{refileLink}</h3>
+  return (
+    <div className="usa-alert-body">
+      {textToRender}
+    </div>
+  )
 }
 
 const getRefileLink = (props) => {
@@ -44,7 +48,7 @@ const RefileWarning = (props) => {
   }
 
   return (
-    <div className={`RefileWarning usa-alert ${alertClass}`}>
+    <div className={`RefileWarning usa-alert ${alertClass} margin-bottom-2`}>
       <div className="usa-alert-body">
         {getText(props)}
       </div>

--- a/src/sass/app.scss
+++ b/src/sass/app.scss
@@ -133,6 +133,20 @@ h6,
   display: inline-block;
 }
 
+.usa-alert {
+  width: 100%;
+}
+
+.usa-alert-error,
+.usa-alert-warning,
+.usa-alert-success {
+  background-image: none;
+}
+
+.usa-alert-body {
+  padding-left: 0;
+}
+
 a {
  cursor: pointer;
 }

--- a/src/sass/app.scss
+++ b/src/sass/app.scss
@@ -14,6 +14,7 @@
 @import "components/BannerUser.scss";
 @import "components/UserHeading.scss";
 @import "components/EditsNav.scss";
+@import "components/ParseErrors.scss";
 
 // fix for disabled and checked checkbox
 [type="checkbox"]:checked:disabled + label::before {

--- a/src/sass/components/EditsHeaderDescription.scss
+++ b/src/sass/components/EditsHeaderDescription.scss
@@ -1,9 +1,9 @@
 .EditsHeaderDescription {
+  border-bottom: 1px solid $color-gray-lighter;
   h2 {
     margin-top: 0;
   }
   p.usa-font-lead {
     margin-top: .5em;
-    margin-bottom: 0;
   }
 }

--- a/src/sass/components/EditsTable.scss
+++ b/src/sass/components/EditsTable.scss
@@ -1,5 +1,8 @@
-.EditsContainerEntry:first-child {
-  margin-top: 3em;
+.EditsContainerEntry {
+  margin-bottom: 6em;
+  &:first-child {
+    margin-top: 3em;
+  }
 }
 .EditsTable {
   margin-top: 3em;

--- a/src/sass/components/ParseErrors.scss
+++ b/src/sass/components/ParseErrors.scss
@@ -1,0 +1,11 @@
+.ParseErrors {
+  .desc {
+    border-bottom: 1px solid $color-gray-lighter;
+  }
+  h2 {
+    margin-top: 0;
+  }
+  p.usa-font-lead {
+    margin-top: .5em;
+  }
+}


### PR DESCRIPTION
Closes #341 

- updates the edits heading, per type and per specific edit to be a little more clear
  - does the same for parse errors too
- updates refile warning for styling

#### Example with edits
![syntactical](https://cloud.githubusercontent.com/assets/2932572/22257497/42efbbac-e22c-11e6-98db-bdcd806e6321.png)

#### Example without edits
![quality](https://cloud.githubusercontent.com/assets/2932572/22257537/62bb505e-e22c-11e6-8b7e-4325e3e91ee1.png)

