### PR TITLE
Summary page headings

### DIFF
--- a/src/js/components/IRSReport.jsx
+++ b/src/js/components/IRSReport.jsx
@@ -8,13 +8,13 @@ const IRSReport = (props) => {
 
   return (
     <div className="IRSReport" id="irs">
-      <div className="padding-2 bg-color-gray-lightest">
-        <h2 className="margin-top-0">Institution Register Summary</h2>
-        <p className="usa-font-lead margin-top-half margin-bottom-0">All MSA/MDs where my institution has a home or branch office (and took loan/applications in that office) are listed on the IRS. Each MSA/MD listed is an MSA/MD in which we have a home or branch office. No depository institutions, including mortgage subsidiaries, are considered to have a branch office in any MSA/MD where they have acted.</p>
+      <div className="border-bottom margin-bottom-3">
+        <h2>Institution Register Summary</h2>
+        <p className="usa-font-lead">All MSA/MDs where my institution has a home or branch office (and took loan/applications in that office) are listed on the IRS. Each MSA/MD listed is an MSA/MD in which we have a home or branch office. No depository institutions, including mortgage subsidiaries, are considered to have a branch office in any MSA/MD where they have acted.</p>
         <p className="usa-font-lead">Please review each of the <strong>{props.msas.length}</strong> MSA/MDs listed below. If you disagree please correct and re-upload the updated file.</p>
       </div>
 
-      <div className="border margin-bottom-5 padding-1">
+      <div className="margin-bottom-5">
         <table className="margin-bottom-0" width="100%">
           <thead>
             <tr>

--- a/src/js/components/Signature.jsx
+++ b/src/js/components/Signature.jsx
@@ -41,10 +41,12 @@ const Signature = (props) => {
     buttonClass = 'usa-button-disabled'
   }
 
+  const headingClass = props.status.code === 11 ? 'text-green' : 'text-secondary'
+
   return (
     <div className="Signature" id="signature">
       <div className="border-bottom margin-bottom-3">
-        <h2>Signature</h2>
+        <h2 className={headingClass}>Signature</h2>
         <p className="usa-font-lead">To complete your submission first check the checkbox to certify accuracy and then click the button to sign.</p>
       </div>
 

--- a/src/js/components/Signature.jsx
+++ b/src/js/components/Signature.jsx
@@ -43,12 +43,12 @@ const Signature = (props) => {
 
   return (
     <div className="Signature" id="signature">
-      <div className="padding-2 bg-color-gray-lightest">
-        <h2 className="margin-top-0">Signature</h2>
-        <p className="usa-font-lead margin-top-half margin-bottom-0">To complete your submission first check the checkbox to certify accuracy and then click the button to sign.</p>
+      <div className="border-bottom margin-bottom-3">
+        <h2>Signature</h2>
+        <p className="usa-font-lead">To complete your submission first check the checkbox to certify accuracy and then click the button to sign.</p>
       </div>
 
-      <div className="border margin-bottom-5 padding-1">
+      <div className="margin-bottom-5">
         {showWarning(props.status.code)}
 
         <ul className="usa-unstyled-list">

--- a/src/js/components/Summary.jsx
+++ b/src/js/components/Summary.jsx
@@ -5,11 +5,11 @@ const Summary = (props) => {
 
   return (
     <div className="Summary usa-grid-full" id="summary">
-      <div className="padding-2 bg-color-gray-lightest">
-        <h2 className="margin-top-0">Validation Summary</h2>
-        <p className="usa-font-lead margin-top-half margin-bottom-0">You have succesfully validated your file. Please review the respondent and file information below.</p>
+      <div className="border-bottom margin-bottom-3">
+        <h2>Validation Summary</h2>
+        <p className="usa-font-lead">You have succesfully validated your file. Please review the respondent and file information below.</p>
       </div>
-      <div className="border margin-bottom-5 padding-1 usa-grid-full">
+      <div className="margin-bottom-5 usa-grid-full">
         <div className="usa-width-one-half">
           <h3>Respondent Information</h3>
           <dl>

--- a/src/sass/app.scss
+++ b/src/sass/app.scss
@@ -213,6 +213,9 @@ dd {
 .margin-bottom-2 {
   margin-bottom: 2em;
 }
+.margin-bottom-3 {
+  margin-bottom: 3em;
+}
 .margin-bottom-5 {
   margin-bottom: 5em;
 }
@@ -252,6 +255,9 @@ dd {
 }
 .border-left {
   border-left: 1px solid $color-gray-lightest;
+}
+.border-bottom {
+  border-bottom: 1px solid $color-gray-lighter;
 }
 
 // max-width reset

--- a/src/sass/components/EditsHeaderDescription.scss
+++ b/src/sass/components/EditsHeaderDescription.scss
@@ -1,5 +1,6 @@
 .EditsHeaderDescription {
   border-bottom: 1px solid $color-gray-lighter;
+  margin-bottom: 3em;
   h2 {
     margin-top: 0;
   }

--- a/src/sass/components/EditsTable.scss
+++ b/src/sass/components/EditsTable.scss
@@ -5,7 +5,6 @@
   }
 }
 .EditsTable {
-  margin-top: 3em;
   &:first-child {
     margin-top: 1em;
   }


### PR DESCRIPTION
Related to #346 and depends on #347 to fix signature component bug.

- changes the /summary components to match the components on /edits
- signaure heading changes based on status (like edits headings)

#### Signature not signed
![signature-not-signed](https://cloud.githubusercontent.com/assets/2932572/22297713/26096be4-e2ec-11e6-991b-607a794d79db.png)

#### Signature signed
![signature-signed](https://cloud.githubusercontent.com/assets/2932572/22297719/2e921072-e2ec-11e6-961b-918ff092832c.png)

#### Full screen
![summary-headings](https://cloud.githubusercontent.com/assets/2932572/22297361/01acc076-e2eb-11e6-8e22-128e4a0d8cf9.png)
