### PR TITLE
Disable macro

### DIFF
--- a/src/js/containers/JustificationSelector.jsx
+++ b/src/js/containers/JustificationSelector.jsx
@@ -35,8 +35,12 @@ class JustificationSelector extends Component {
   }
 
   render() {
-    const { syntax, validity } = this.props.edits.types
-    const disabled = (this.props.code === 8 && (validity.length === 0 && syntax.length === 0)) ? false : true
+    const { syntactical, validity } = this.props.edits.types
+    let disabled = true
+    // if the submission is in any other status but signed AND there are no syntactical and validity edits, enable it
+    if (this.props.code !== 11 && (validity.edits.length === 0 && syntactical.edits.length === 0)) {
+      disabled = false
+    }
     return (
       <Select
         allowCreate={true}

--- a/src/js/containers/JustificationSelector.jsx
+++ b/src/js/containers/JustificationSelector.jsx
@@ -35,6 +35,8 @@ class JustificationSelector extends Component {
   }
 
   render() {
+    const { syntax, validity } = this.props.edits.types
+    const disabled = (this.props.code === 8 && (validity.length === 0 && syntax.length === 0)) ? false : true
     return (
       <Select
         allowCreate={true}
@@ -45,13 +47,23 @@ class JustificationSelector extends Component {
         value={this.state && this.state.value}
         onChange={this.props.dispatchOnChange.bind(this)}
         options={this.labelledJustifications}
+        disabled={disabled}
       />
     )
   }
 }
 
 function mapStateToProps(state, ownProps) {
-  return { ...ownProps }
+  const code = state.app.submission.status.code || null
+
+  // can remove the edits if we later update status to include a status for syntax/validity edits and separate status for quality/macro
+  const edits = state.app.edits || null
+
+  return {
+    ...ownProps,
+    code,
+    edits
+  }
 }
 
 function mapDispatchToProps(dispatch, ownProps){


### PR DESCRIPTION
Closes part of #290 

- enable macro justifications when not signed and there are no syntactical and validity edits

To visually test you can use the file in https://github.com/cfpb/hmda-platform/pull/793.