### PR TITLE
remove unused return

### DIFF
--- a/src/js/components/UploadForm.jsx
+++ b/src/js/components/UploadForm.jsx
@@ -81,17 +81,6 @@ class Upload extends Component {
         </div>
       </div>
     )
-    return(
-      errors.map((error, i) => {
-        return(
-          <div key={i} className="usa-alert usa-alert-error" role="alert">
-            <div className="usa-alert-body">
-              <p className="usa-alert-text">{error}</p>
-            </div>
-          </div>
-        )
-      })
-    )
   }
 
   render() {


### PR DESCRIPTION
@wpears - I just noticed this after the merge. There was a 2nd `return` that I had in there while testing, this removes it.