### PR TITLE
Fix NPM errors by adding git to Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,7 @@ FROM nginx:1.10
 MAINTAINER Wyatt Pearsall<Wyatt.Pearsall@cfpb.gov>
 
 RUN apt-get update && \
-    apt-get install -y curl && \
-    apt-get install -y make && \
-    apt-get install -y g++ && \
+    apt-get install -y curl g++ git make && \
     curl -sL https://deb.nodesource.com/setup_6.x | bash - && \
     apt-get install -y nodejs && \
     mkdir -p /usr/src/app


### PR DESCRIPTION
I am currently getting the following error when trying to do from scratch Docker build:

```
npm ERR! git clone --template=/root/.npm/_git-remotes/_templates --mirror git@github.com:thoughtbot/neat.git /root/.npm/_git-remotes/git-github-com-thoughtbot-neat-git-neat-1-8-0-node-sass-31bad44b: undefined
npm ERR! git clone --template=/root/.npm/_git-remotes/_templates --mirror git@github.com:thoughtbot/neat.git /root/.npm/_git-remotes/git-github-com-thoughtbot-neat-git-neat-1-8-0-node-sass-31bad44b: undefined
npm ERR! Linux 4.4.47-boot2docker
npm ERR! argv "/usr/bin/nodejs" "/usr/bin/npm" "install"
npm ERR! node v6.9.5
npm ERR! npm  v3.10.10
npm ERR! code ENOGIT

npm ERR! not found: git
npm ERR!
npm ERR! Failed using git.
npm ERR! This is most likely not a problem with npm itself.
npm ERR! Please check if you have git installed and in your PATH.
```

Once I installed `git`, all was well again.  Not quite sure why this is happening.  One of the upstream images (`nginx:1.10` or `debian:jessie`) must have removed `git` as a dependency.