### PR TITLE
Home page to use UserHeading

### DIFF
--- a/__tests__/components/UserHeading.js
+++ b/__tests__/components/UserHeading.js
@@ -15,9 +15,11 @@ const data = {
 
 describe('UserHeading', () => {
 
-  describe('does NOT render without user', () => {
+  describe('does NOT render without period', () => {
     const heading = TestUtils.renderIntoDocument(
-      <Wrapper><UserHeading period={data.period} userName=''/></Wrapper>
+      <Wrapper>
+        <UserHeading userName='' />
+      </Wrapper>
     )
     const headingNode = ReactDOM.findDOMNode(heading)
 
@@ -26,9 +28,13 @@ describe('UserHeading', () => {
     })
   })
 
-  describe('render without institution', () => {
+  describe('render with username', () => {
     const heading = TestUtils.renderIntoDocument(
-      <Wrapper><UserHeading userName={data.user} period={data.period}/></Wrapper>
+      <Wrapper>
+        <UserHeading
+          userName={data.user}
+          period={data.period} />
+      </Wrapper>
     )
     const headingNode = ReactDOM.findDOMNode(heading)
 
@@ -41,13 +47,18 @@ describe('UserHeading', () => {
     })
 
     it('renders correctly', () => {
-      expect(headingNode.textContent).toEqual('Welcome to the 2017 HMDA filing, User1')
+      expect(headingNode.textContent).toEqual('Welcome to the 2017 HMDA filing, User1.')
     })
   })
 
   describe('render with institution', () => {
     const heading = TestUtils.renderIntoDocument(
-      <Wrapper><UserHeading institution={data.institution} userName={data.user} period={data.period} /></Wrapper>
+      <Wrapper>
+        <UserHeading
+          institution={data.institution}
+          userName={data.user}
+          period={data.period} />
+      </Wrapper>
     )
     const headingNode = ReactDOM.findDOMNode(heading)
 
@@ -60,7 +71,7 @@ describe('UserHeading', () => {
     })
 
     it('renders correctly', () => {
-      expect(headingNode.textContent).toEqual('Filing on behalf of Wacky data')
+      expect(headingNode.textContent).toEqual('User1 filing on behalf of Wacky data for 2017.')
     })
   })
 

--- a/src/js/components/Home.jsx
+++ b/src/js/components/Home.jsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import Header from '../components/Header.jsx'
+import UserHeading from '../components/UserHeading.jsx'
 import { Link } from 'react-router'
 import { signinRedirect } from '../redirect.js'
 
@@ -28,9 +29,14 @@ const Home = (props) => {
       <div className="Home" id="main-content">
         <div className="usa-grid">
           <div className="usa-width-one-whole">
-            <h2>Welcome to HMDA Filing{props.user.profile.name ? ' ' + props.user.profile.name : ''}
-            <Link className="usa-button" to="/institutions">{props.user.profile.name ? 'Begin Filing' : 'Login and Begin Filing'}</Link>
-            </h2>
+            <Link
+              className="usa-button login-button"
+              to="/institutions">
+              {props.user.profile.name ? 'Begin Filing' : 'Login and Begin Filing'}
+            </Link>
+            <UserHeading
+              period={props.filingPeriod}
+              userName={props.user.profile.name} />
 
             {getLoginMessage(props.user.profile.name)}
 

--- a/src/js/components/UserHeading.jsx
+++ b/src/js/components/UserHeading.jsx
@@ -1,14 +1,17 @@
 import React, { PropTypes } from 'react'
 
 const getText = (props) => {
+  // not logged in, on home page
   let headingText = `Welcome to the ${props.period} HMDA filing.`
 
+  // logged in, on home page
   if(props.userName) {
     headingText = `Welcome to the ${props.period} HMDA filing, ${props.userName}.`
   }
 
-  if (props.institution) {
-    headingText = `Filing on behalf of ${props.institution} for ${props.period}.`
+  // logged in, submission pages
+  if(props.institution) {
+    headingText = `${props.userName} filing on behalf of ${props.institution} for ${props.period}.`
   }
 
   return headingText

--- a/src/js/components/UserHeading.jsx
+++ b/src/js/components/UserHeading.jsx
@@ -1,26 +1,29 @@
 import React, { PropTypes } from 'react'
 
 const getText = (props) => {
-  let headingText = 'Welcome to the ' + props.period + ' HMDA filing, ' + props.userName
+  let headingText = `Welcome to the ${props.period} HMDA filing.`
+
+  if(props.userName) {
+    headingText = `Welcome to the ${props.period} HMDA filing, ${props.userName}.`
+  }
 
   if (props.institution) {
-    headingText = 'Filing on behalf of ' + props.institution;
+    headingText = `Filing on behalf of ${props.institution} for ${props.period}.`
   }
 
   return headingText
 }
 
 const UserHeading = (props) => {
-  if(!props.userName) return null
+  if(!props.period) return null
 
-  const headingText = getText(props)
   return (
-    <h2 className="UserHeading">{headingText}</h2>
+    <h2 className="UserHeading">{getText(props)}</h2>
   )
 }
 
 UserHeading.propTypes = {
-  userName: React.PropTypes.string.isRequired,
+  userName: React.PropTypes.string,
   period: React.PropTypes.string.isRequired,
   institution: React.PropTypes.string
 }

--- a/src/js/containers/Home.jsx
+++ b/src/js/containers/Home.jsx
@@ -17,6 +17,7 @@ export class HomeContainer extends Component {
 export function mapStateToProps(state) {
   return {
     user: state.oidc.user || {profile: {name: null}},
+    filingPeriod: state.app.filingPeriod,
     viewInstitutions(e) {
       e.preventDefault()
       browserHistory.push('/institutions')

--- a/src/sass/components/ConfirmationModal.scss
+++ b/src/sass/components/ConfirmationModal.scss
@@ -1,20 +1,19 @@
 .confirmation-modal {
   position: fixed;
-  left:50%;
-  top:50%;
+  left: 50%;
+  top: 50%;
   transform: translate(-50%,-50%);
-  padding:2em 3em;
-  z-index:9003;
-  background:$color-gray-lightest;
-  border-radius: 4px;
-  box-shadow: 0 0 4px -1px $color-gray-warm-dark, 0 1px 2px -1px $color-gray-warm-dark;
+  padding: 2em 3em;
+  z-index: 9003;
+  background: $color-white;
+  border-radius: .3rem;
 }
 
 .confirmation-blurred-blocker {
   background: rgba(255,255,255,0);
-  display:none;
+  display: none;
   position: absolute;
-  top:0;
+  top: 0;
   bottom: 0;
   left: 0;
   right: 0;
@@ -22,6 +21,6 @@
 }
 
 div.showing-blurred-blocker {
-  background: rgba(255,255,255,0.9);
+  background: rgba(0,0,0,0.6);
   display:block;
 }

--- a/src/sass/components/Home.scss
+++ b/src/sass/components/Home.scss
@@ -12,7 +12,11 @@
     margin-bottom: 2em;
   }
 
-  h2 > .usa-button {
+  h2 {
+    display: inline-block;
+  }
+
+  .login-button {
     float:right;
   }
 


### PR DESCRIPTION
While starting to look more into #373 I noticed the home page wasn't using the `<UserHeading />`.

This PR does that, plus it updates the refiling modal to make it a little more apparent, IMO.

![modal](https://cloud.githubusercontent.com/assets/2932572/23076467/9e369158-f50e-11e6-9321-46bf72fe4806.png)
