### PR TITLE
Add descriptions for edits

### DIFF
--- a/__tests__/components/EditsTable.js
+++ b/__tests__/components/EditsTable.js
@@ -1,5 +1,4 @@
 jest.unmock('../../src/js/components/EditsTable.jsx')
-jest.unmock('../../src/js/components/EditsTableRow.jsx')
 
 import EditsTable, {
   formatHeader,

--- a/__tests__/components/EditsTable.js
+++ b/__tests__/components/EditsTable.js
@@ -1,6 +1,13 @@
 jest.unmock('../../src/js/components/EditsTable.jsx')
+jest.unmock('../../src/js/components/EditsTableRow.jsx')
 
-import EditsTable from '../../src/js/components/EditsTable.jsx'
+import EditsTable, {
+  formatHeader,
+  renderHeader,
+  renderBody,
+  renderTableCaption,
+  makeTables
+} from '../../src/js/components/EditsTable.jsx'
 import Wrapper from '../Wrapper.js'
 import fs from 'fs'
 import React from 'react'
@@ -24,4 +31,172 @@ describe('Edits Table', () => {
     expect(tableNode).toBeDefined()
   })
 
+  const editsTableNoEdits = TestUtils.renderIntoDocument(
+    <Wrapper><EditsTable type='syntactical'/></Wrapper>
+  )
+  const tableNoEditsNode = ReactDOM.findDOMNode(editsTableNoEdits)
+  it('is NULL without edits', () => {
+    expect(tableNoEditsNode).toBe(null)
+  })
+})
+
+describe('formatHeader', () => {
+  it('returns the correct text', () => {
+    let header = formatHeader('rowId')
+    expect(header).toBe('Row ID')
+
+    header = formatHeader('edit')
+    expect(header).toBe('Edit ID')
+
+    header = formatHeader('editId')
+    expect(header).toBe('Edit ID')
+
+    header = formatHeader('justifications')
+    expect(header).toBe('Justifications')
+
+    header = formatHeader('description')
+    expect(header).toBe('Description')
+
+    header = formatHeader('this is made up')
+    expect(header).toBe('this is made up')
+  })
+})
+
+describe('renderHeader', () => {
+  it('renders header with syntactical', () => {
+    const edits = types.syntactical.edits[0]
+    const rendered = renderHeader(edits, 'syntactical')
+    expect(rendered.type).toBe('tr')
+    expect(rendered.props.children[0].props.children).toBe('Row ID')
+    expect(rendered.props.children[1].props.children).toBe('Agency Code')
+  })
+
+  it('renders header with validity', () => {
+    const edits = types.validity.edits[0]
+    const rendered = renderHeader(edits, 'validity')
+    expect(rendered.type).toBe('tr')
+    expect(rendered.props.children[0].props.children).toBe('Row ID')
+    expect(rendered.props.children[1].props.children).toBe('Lien Status')
+  })
+
+  it('renders header by row', () => {
+    const edits = {
+      description: types.syntactical.edits[0].description,
+      editId: types.syntactical.edits[0].edit,
+      fields: types.syntactical.edits[0].rows[0].fields
+    }
+    const rendered = renderHeader(edits, 'rows')
+    expect(rendered.type).toBe('tr')
+    expect(rendered.props.children[0].props.children).toBe('Edit ID')
+    expect(rendered.props.children[1].props.children).toBe('Agency Code')
+  })
+
+  it('renders header with quality', () => {
+    const edits = types.quality.edits[0]
+    const rendered = renderHeader(edits, 'quality')
+    expect(rendered.type).toBe('tr')
+    expect(rendered.props.children[0].props.children).toBe('Row ID')
+    expect(rendered.props.children[1].props.children).toBe('Agency Code')
+  })
+
+  it('renders header with macro', () => {
+    const edits = types.macro.edits
+    const rendered = renderHeader(edits, 'macro')
+    expect(rendered.type).toBe('tr')
+    expect(rendered.props.children[0].props.children).toBe('Edit ID')
+    expect(rendered.props.children[1].props.children).toBe('Justifications')
+  })
+})
+
+describe('renderBody', () => {
+  it('renders body with syntactical', () => {
+    const edits = types.syntactical.edits[0]
+    const rendered = renderBody(edits, 'syntactical')
+    expect(rendered.length).toEqual(3)
+    expect(TestUtils.isElement(rendered[0])).toBe(true)
+  })
+
+  it('renders body with validity', () => {
+    const edits = types.validity.edits[0]
+    const rendered = renderBody(edits, 'validity')
+    expect(rendered.length).toEqual(1)
+    expect(TestUtils.isElement(rendered[0])).toBe(true)
+  })
+
+  it('renders body by row', () => {
+    const edits = {
+      description: types.syntactical.edits[0].description,
+      editId: types.syntactical.edits[0].edit,
+      fields: types.syntactical.edits[0].rows[0].fields
+    }
+    const rendered = renderBody(edits, 'rows')
+    expect(TestUtils.isElement(rendered)).toBe(true)
+  })
+
+  it('renders body with quality', () => {
+    const edits = types.quality.edits[0]
+    const rendered = renderBody(edits, 'quality')
+    expect(rendered.length).toEqual(3)
+    expect(TestUtils.isElement(rendered[0])).toBe(true)
+  })
+
+  it('renders body with macro', () => {
+    const edits = types.macro.edits
+    const rendered = renderBody(edits, 'macro')
+    expect(rendered.length).toEqual(1)
+    expect(TestUtils.isElement(rendered[0])).toBe(true)
+  })
+})
+
+describe('renderTableCaption', () => {
+  it('renders the caption with a description', () => {
+    const edits = types.syntactical.edits[0]
+    const rendered = renderTableCaption(edits)
+    expect(rendered.type).toBe('caption')
+    expect(rendered.props.children[0].props.children).toBe('3 S020 edits found.')
+  })
+
+  it('renders the caption WITHOUT a description', () => {
+    const object = {
+      rowId: '1234',
+      edits: [
+        {
+          description: types.syntactical.edits[0].description,
+          editId: types.syntactical.edits[0].edit,
+          fields: types.syntactical.edits[0].rows[0].fields
+        }
+      ]
+    }
+    const rendered = renderTableCaption(object)
+    expect(rendered.type).toBe('caption')
+    expect(rendered.props.children[0].props.children).toBe('1 edit found in row 1234.')
+    expect(rendered.props.children.length).toBe(2)
+    expect(rendered.props.children[1]).toBe(null)
+  })
+
+  it('returns null without a name', () => {
+    const object = {
+      edits: [
+        {
+          description: types.syntactical.edits[0].description,
+          editId: types.syntactical.edits[0].edit,
+          fields: types.syntactical.edits[0].rows[0].fields
+        }
+      ]
+    }
+    const rendered = renderTableCaption(object)
+    expect(rendered).toBe(null)
+  })
+})
+
+describe('makeTables', () => {
+  it('renders the table', () => {
+    const props = {
+      edits: types.syntactical.edits[0],
+      type: 'syntactical'
+    }
+    const rendered = makeTables(props)
+    expect(rendered.type).toBe('table')
+    expect(rendered.props.children.length).toBe(3)
+  })
 })

--- a/src/js/components/EditsTable.jsx
+++ b/src/js/components/EditsTable.jsx
@@ -18,12 +18,12 @@ export const renderHeader = (edits, type) => {
   let fieldCells = {}
   const cells = []
 
-  if (type === 'macro' ){
+  if (type === 'macro' ) {
     keyCells = edits[0]
-  }else if (type === 'rows' ){
-    keyCells = {editId: edits.editId}
+  } else if (type === 'rows' ) {
+    keyCells = { editId: edits.editId }
     fieldCells = edits.fields
-  }else{
+  } else {
     keyCells = edits.rows[0].row
     fieldCells = edits.rows[0].fields
   }
@@ -56,7 +56,7 @@ export const renderBody = (edits, type) => {
   })
 }
 
-const makeTableLabel = (edits) => {
+export const renderTableCaption = (edits) => {
   let name
   let description
   let length
@@ -65,7 +65,7 @@ const makeTableLabel = (edits) => {
     name = edits.edit
     description = edits.description
     length = edits.rows.length
-  }else if(edits.rowId) {
+  } else if(edits.rowId) {
     name = edits.rowId
     length = edits.edits.length
   }
@@ -74,20 +74,26 @@ const makeTableLabel = (edits) => {
 
   const editText = length === 1 ? 'edit' : 'edits'
 
+  let captionHeader = `${length} ${name} ${editText} found.`
   if(edits.rowId && name !== 'Transmittal Sheet'){
-    return `${length} ${editText} found in row ${name}.`
+    captionHeader = `${length} ${editText} found in row ${name}.`
   }
 
-  return `${length} ${name} ${editText} found.`
+  return (
+    <caption>
+      <h3>{captionHeader}</h3>
+      {description ? <p className="usa-font-lead">{description}</p>:null}
+    </caption>
+  )
 }
 
-const makeTables = (props) => {
+export const makeTables = (props) => {
   const edits = props.edits
 
   const makeTable = (edit, i) => {
     return (
     <table width="100%" key={i}>
-      {i === 0 ? <caption><h3>{makeTableLabel(edits)}</h3></caption>:null}
+      {i === 0 ? renderTableCaption(edits):null}
       <thead>
         {renderHeader(edit, props.type)}
       </thead>

--- a/src/sass/components/EditsHeaderDescription.scss
+++ b/src/sass/components/EditsHeaderDescription.scss
@@ -1,5 +1,4 @@
 .EditsHeaderDescription {
-  margin-bottom: 1em;
   h2 {
     margin-top: 0;
   }

--- a/src/sass/components/EditsTable.scss
+++ b/src/sass/components/EditsTable.scss
@@ -9,9 +9,7 @@
   }
 }
 .EditsTable {
-  &:first-child {
-    margin-top: 1em;
-  }
+  margin-top: 3em;
   caption {
     padding-bottom: 1em;
     text-align: left;


### PR DESCRIPTION
Closes #394 

- adds descriptions back to the table captions
- updates tests