### PR TITLE
Render FI name in UserHeading

### DIFF
--- a/__tests__/actions/actions.js
+++ b/__tests__/actions/actions.js
@@ -68,22 +68,22 @@ const getEachInstitution = [
   {type: types.REQUEST_INSTITUTION},
   {
     type: types.RECEIVE_INSTITUTION,
-    institution: institutionsDetailObj['0']
+    institution: institutionsDetailObj['0'].institution
   },
   {type:types.CLEAR_FILINGS},
   {
     type: types.RECEIVE_INSTITUTION,
-    institution: institutionsDetailObj['1']
+    institution: institutionsDetailObj['1'].institution
   },
   {type:types.CLEAR_FILINGS},
   {
     type: types.RECEIVE_INSTITUTION,
-    institution: institutionsDetailObj['2']
+    institution: institutionsDetailObj['2'].institution
   },
   {type:types.CLEAR_FILINGS},
   {
     type: types.RECEIVE_INSTITUTION,
-    institution: institutionsDetailObj['3']
+    institution: institutionsDetailObj['3'].institution
   },
   {type:types.CLEAR_FILINGS},
   {type:types.RECEIVE_FILINGS},
@@ -183,7 +183,7 @@ describe('actions', () => {
 
     expect(actions.receiveInstitution(data)).toEqual({
       type: types.RECEIVE_INSTITUTION,
-      institution: data
+      institution: data.institution
     })
   })
 
@@ -275,14 +275,10 @@ describe('actions', () => {
   it('creates a thunk that will send an http request for an institution by id', done => {
     const store = mockStore({filings: []})
 
-    store.dispatch(actions.fetchInstitution({id: 'bank0id'}))
+    store.dispatch(actions.fetchInstitution({id: 'bank0id'}, false))
       .then(() => {
         expect(store.getActions()).toEqual([
-          {type: types.REQUEST_INSTITUTION},
-          {
-            type: types.RECEIVE_INSTITUTION,
-            institution: institutionsDetailObj.bank0id
-          }
+          {type: types.REQUEST_INSTITUTION}
         ])
         done()
       })

--- a/__tests__/components/UserHeading.js
+++ b/__tests__/components/UserHeading.js
@@ -8,7 +8,10 @@ import TestUtils from 'react-addons-test-utils'
 
 const data = {
   user: 'User1',
-  institution: "Wacky data",
+  institution: {
+    id: '1',
+    name: 'Wacky data'
+  },
   period: '2017'
 }
 
@@ -67,7 +70,7 @@ describe('UserHeading', () => {
     })
 
     it('passes through the institution appropriately as props', () => {
-      expect(heading.props.children.props.institution).toEqual("Wacky data")
+      expect(heading.props.children.props.institution).toEqual(data.institution)
     })
 
     it('renders correctly', () => {

--- a/src/js/actions/index.js
+++ b/src/js/actions/index.js
@@ -244,6 +244,7 @@ export function fetchIRS() {
     dispatch(requestIRS())
     return getIRS(latestSubmissionId)
       .then(json => {
+        if(!json) return
         dispatch(receiveIRS(json))
         dispatch(updateStatus(
           {
@@ -573,8 +574,9 @@ export function fetchInstitution(institution, fetchFilings = true) {
     dispatch(requestInstitution())
     return getInstitution(institution.id)
       .then(json => {
+        if(!json) return
         dispatch(receiveInstitution(json))
-        if(json && json.filings && fetchFilings){
+        if(json.filings && fetchFilings){
           return dispatch(fetchEachFiling(json.filings))
         }
       })

--- a/src/js/actions/index.js
+++ b/src/js/actions/index.js
@@ -60,7 +60,7 @@ export function requestInstitution() {
 export function receiveInstitution(data) {
   return {
     type: types.RECEIVE_INSTITUTION,
-    institution: data
+    institution: data.institution
   }
 }
 

--- a/src/js/actions/index.js
+++ b/src/js/actions/index.js
@@ -568,13 +568,13 @@ export function fetchEachInstitution(institutions) {
 /*
  * Fetch an institution via the api and dispatch an action with the results
  */
-export function fetchInstitution(institution) {
+export function fetchInstitution(institution, fetchFilings = true) {
   return dispatch => {
     dispatch(requestInstitution())
     return getInstitution(institution.id)
       .then(json => {
         dispatch(receiveInstitution(json))
-        if(json && json.filings){
+        if(json && json.filings && fetchFilings){
           return dispatch(fetchEachFiling(json.filings))
         }
       })

--- a/src/js/components/UserHeading.jsx
+++ b/src/js/components/UserHeading.jsx
@@ -11,7 +11,7 @@ const getText = (props) => {
 
   // logged in, submission pages
   if(props.institution) {
-    headingText = `${props.userName} filing on behalf of ${props.institution} for ${props.period}.`
+    headingText = `${props.userName} filing on behalf of ${props.institution.name} for ${props.period}.`
   }
 
   return headingText
@@ -28,7 +28,7 @@ const UserHeading = (props) => {
 UserHeading.propTypes = {
   userName: React.PropTypes.string,
   period: React.PropTypes.string.isRequired,
-  institution: React.PropTypes.string
+  institution: React.PropTypes.object
 }
 
 export default UserHeading

--- a/src/js/containers/Submission.jsx
+++ b/src/js/containers/Submission.jsx
@@ -1,7 +1,10 @@
 import React, { Component, PropTypes } from 'react'
 import { Link } from 'react-router'
 import { connect } from 'react-redux'
-import { fetchSubmission } from '../actions'
+import {
+  fetchSubmission,
+  fetchInstitution
+} from '../actions'
 import HomeLink from '../components/HomeLink.jsx'
 import Header from '../components/Header.jsx'
 import UserHeading from '../components/UserHeading.jsx'
@@ -63,9 +66,14 @@ class SubmissionContainer extends Component {
   }
 
   componentDidMount() {
+    const institution = {
+      id: this.props.params.institution
+    }
     if(!this.props.status && this.props.dispatch){
       this.props.dispatch(fetchSubmission())
     }
+
+    this.props.dispatch(fetchInstitution(institution, false))
   }
 
   render() {
@@ -93,7 +101,7 @@ class SubmissionContainer extends Component {
         <UserHeading
           period={params.filing}
           userName={user.profile.name}
-          institution={params.institution} />
+          institution={this.props.institution} />
         {code > 2 ? <RefileButton
           id={params.institution}
           filing={params.filing}
@@ -119,10 +127,13 @@ function mapStateToProps(state) {
 
   const user = state.oidc && state.oidc.user || null
 
+  const institution = state.app.institution
+
   return {
     isFetching,
     status,
-    user
+    user,
+    institution
   }
 }
 

--- a/src/js/reducers/index.js
+++ b/src/js/reducers/index.js
@@ -1,6 +1,8 @@
 import { combineReducers } from 'redux'
 import {
   REFRESH_STATE,
+  REQUEST_INSTITUTION,
+  RECEIVE_INSTITUTION,
   REQUEST_INSTITUTIONS,
   RECEIVE_INSTITUTIONS,
   CLEAR_FILINGS,
@@ -82,6 +84,32 @@ const defaultEdits = {
 //empty action logger, temporary / for debugging
 export const auth = (state = {}, action) => {
   return state
+}
+
+const defaultInstitution = {
+  isFetching: false,
+  id: '',
+  name: ''
+}
+
+export const institution = (state = defaultInstitution, action) => {
+  switch(action.type) {
+    case REQUEST_INSTITUTION:
+    return {
+      ...state,
+      isFetching: true
+    }
+
+    case RECEIVE_INSTITUTION:
+    return {
+      isFetching: false,
+      id: action.institution.id,
+      name: action.institution.name
+    }
+
+    default:
+    return state
+  }
 }
 
 /*
@@ -415,6 +443,7 @@ export const parseErrors = (state = defaultParseErrors, action) => {
 
 export default combineReducers({
   auth,
+  institution,
   institutions,
   filings,
   filingPeriod,


### PR DESCRIPTION
Closes #387 

- updates `fetchInstitution` action to allow it to only return the institution data
- adds that action to the `Submission` container to get the current institution
- renders the institution name (instead of the id) in the `UserHeading`