### PR TITLE
updates to help the compose build time

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,13 @@
 FROM nginx:1.10
 MAINTAINER Wyatt Pearsall<Wyatt.Pearsall@cfpb.gov>
 
-RUN apt-get update && \
-    apt-get install -y curl g++ git make && \
-    curl -sL https://deb.nodesource.com/setup_7.x | bash - && \
-    apt-get install -y nodejs && \
-    mkdir -p /usr/src/app
+RUN mkdir -p /usr/src/app
 
 WORKDIR /usr/src/app
-COPY . /usr/src/app
+# COPY . /usr/src/app
 COPY nginx/nginx.conf /etc/nginx/nginx.conf
 
-RUN chown -R root /usr/src/app && chmod u+rwx /usr/src/app
-
-RUN npm cache clean && \
-    npm install && \
-    npm run clean && \
-    npm run build
+# RUN chown -R root /usr/src/app && chmod u+rwx /usr/src/app
 
 EXPOSE 80
 


### PR DESCRIPTION
Steps I took to test the build times:
- removed all containers and images
- ran `time docker-compose up -d --build`

Results:
```
real	11m7.019s
user	0m15.813s
sys	0m5.301s
```

Then:
- made updates to the UI dockerfile
- removed all containers and images again
- ran `time docker-compose up -d --build` again

Results:
```
real	7m50.625s
user	0m15.689s
sys	0m5.264s
```

Looks like it trimmed a little over 3 minutes.