### PR TITLE
ErrorWarning component implemented and error key added to state

### DIFF
--- a/__tests__/actions/actions.js
+++ b/__tests__/actions/actions.js
@@ -37,7 +37,7 @@ getLatestSubmission.mockImplementation(() => Promise.resolve(filingsObj.submissi
 getSubmission.mockImplementation(() => Promise.resolve(filingsObj.submissions[2]))
 getIRS.mockImplementation((id) => Promise.resolve(IRSObj))
 getSignature.mockImplementation((id) => Promise.resolve(signatureObj))
-postQuality.mockImplementation(() => Promise.resolve())
+postQuality.mockImplementation(() => Promise.resolve({}))
 getEdits.mockImplementation((id) => Promise.resolve({fakeEdits:1}))
 
 delete global.XMLHttpRequest
@@ -288,10 +288,15 @@ describe('actions', () => {
   it('creates a thunk that will send an http request for an institution by id', done => {
     const store = mockStore({filings: []})
 
-    store.dispatch(actions.fetchInstitution({id: 'bank0id'}, false))
+    store.dispatch(actions.fetchInstitution({id: '0'}, false))
       .then(() => {
         expect(store.getActions()).toEqual([
-          {type: types.REQUEST_INSTITUTION}
+          {type: types.REQUEST_INSTITUTION},
+          {type: types.RECEIVE_INSTITUTION, institution: {
+            id: '0',
+            name: 'Bank 0',
+            status: 'active'
+          }}
         ])
         done()
       })

--- a/__tests__/components/ErrorWarning.js
+++ b/__tests__/components/ErrorWarning.js
@@ -51,6 +51,11 @@ describe('ErrorWarning', () => {
     expect(rendered).toEqual('Sorry, an error has occurred.')
   })
 
+  it('renders correct header with provided text', () => {
+    const rendered = renderHeader({error: {httpStatus: 405}, headerText: 'hi'})
+    expect(rendered).toEqual('hi')
+  })
+
   it('renders correct body on 403', () => {
     const rendered = renderBody({error: {httpStatus: 403}})
     expect(rendered).toEqual('Please refresh the page to log in again.')
@@ -71,4 +76,8 @@ describe('ErrorWarning', () => {
     expect(rendered).toEqual('Please refresh the page. If this message persists, you will need to upload your file again.')
   })
 
+  it('renders correct body with provided text', () => {
+    const rendered = renderBody({error: {httpStatus: 405}, bodyText: 'hi'})
+    expect(rendered).toEqual('hi')
+  })
 })

--- a/__tests__/components/ErrorWarning.js
+++ b/__tests__/components/ErrorWarning.js
@@ -1,0 +1,74 @@
+jest.unmock('../../src/js/components/ErrorWarning.jsx')
+
+import ErrorWarning, { renderHeader, renderBody } from '../../src/js/components/ErrorWarning.jsx'
+import Wrapper from '../Wrapper.js'
+import React from 'react'
+import ReactDOM from 'react-dom'
+import TestUtils from 'react-addons-test-utils'
+
+
+describe('ErrorWarning', () => {
+
+  const errorWarning = TestUtils.renderIntoDocument(
+    <Wrapper>
+      <ErrorWarning error={{httpStatus: 500}}/>
+    </Wrapper>
+  )
+  const warningNode = ReactDOM.findDOMNode(errorWarning)
+
+  it('renders the warning', () => {
+    expect(warningNode).toBeDefined()
+  })
+
+  const nullError = TestUtils.renderIntoDocument(
+    <Wrapper>
+      <ErrorWarning/>
+    </Wrapper>
+  )
+  const nullNode = ReactDOM.findDOMNode(nullError)
+
+  it('renders the nulled error as null', () => {
+    expect(nullNode).toBe(null)
+  })
+
+  it('renders correct header on 403', () => {
+    const rendered = renderHeader({error: {httpStatus: 403}})
+    expect(rendered).toEqual('You have been automatically logged out.')
+  })
+
+  it('renders correct header on 404', () => {
+    const rendered = renderHeader({error: {httpStatus: 404}})
+    expect(rendered).toEqual('Sorry, there is an unrecoverable problem with this filing.')
+  })
+
+  it('renders correct header on 500', () => {
+    const rendered = renderHeader({error: {httpStatus: 500}})
+    expect(rendered).toEqual('Sorry, there\'s a problem on our end.')
+  })
+
+  it('renders correct header on unknown error', () => {
+    const rendered = renderHeader({error: {httpStatus: 405}})
+    expect(rendered).toEqual('Sorry, an error has occurred.')
+  })
+
+  it('renders correct body on 403', () => {
+    const rendered = renderBody({error: {httpStatus: 403}})
+    expect(rendered).toEqual('Please refresh the page to log in again.')
+  })
+
+  it('renders correct body on 404', () => {
+    const rendered = renderBody({error: {httpStatus: 404}})
+    expect(rendered).toEqual('Please upload your file again.')
+  })
+
+  it('renders correct body on 500', () => {
+    const rendered = renderBody({error: {httpStatus: 500}})
+    expect(rendered).toEqual('We\'re quickly on resolving the issue. Please try again soon.')
+  })
+
+  it('renders correct body on unknown error', () => {
+    const rendered = renderBody({error: {httpStatus: 405}})
+    expect(rendered).toEqual('Please refresh the page. If this message persists, you will need to upload your file again.')
+  })
+
+})

--- a/__tests__/reducers/reducers.js
+++ b/__tests__/reducers/reducers.js
@@ -1,7 +1,7 @@
 jest.unmock('../../src/js/reducers')
 
 import * as types from '../../src/js/constants'
-import { pagination, edits, institutions, confirmation, filings, submission, upload, status, irs, signature } from '../../src/js/reducers'
+import { error, pagination, edits, institutions, confirmation, filings, submission, upload, status, irs, signature } from '../../src/js/reducers'
 
 const typesArr = Object.keys(types)
   .filter( v => v !== '__esModule')
@@ -71,6 +71,35 @@ const defaultEdits = {
 const defaultPagination = {
   parseErrors: null
 }
+
+const defaultError = null
+
+describe('error reducer', () => {
+  it('should return the initial state on empty action', () => {
+    expect(
+      error(undefined, {})
+    ).toEqual(defaultError)
+  })
+
+  it('should update the error state when encountered', () => {
+    expect(
+      error(defaultError, {type: types.RECEIVE_ERROR, error: 'an error'})
+    ).toEqual('an error')
+  })
+
+  it('should refresh error state', () => {
+    expect(
+      error({}, {type: types.REFRESH_STATE})
+    ).toEqual(defaultError)
+  })
+
+  it('shouldn\'t modify state on an unknown action type', () => {
+    excludeTypes(types.REFRESH_STATE, types.RECEIVE_ERROR)
+      .forEach(v => expect(error({}, v))
+        .toEqual({})
+      )
+  })
+})
 
 describe('pagination reducer', () => {
   it('should return the initial state on empty action', () => {

--- a/src/js/api.js
+++ b/src/js/api.js
@@ -56,6 +56,7 @@ export function sendFetch(options = {method: 'GET'}){
         return response.text()
       }
       const json = response.json()
+      console.log('got api response for', url, json)
       return json
     })
 }

--- a/src/js/components/ErrorWarning.jsx
+++ b/src/js/components/ErrorWarning.jsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { PropTypes } from 'react'
 
 export function renderHeader(props) {
   if(props.headerText) return props.headerText
@@ -47,6 +47,12 @@ const ErrorWarning = (props) => {
       </div>
     </div>
   )
+}
+
+ErrorWarning.propTypes = {
+  error: PropTypes.object,
+  bodyText: PropTypes.string,
+  headerText: PropTypes.string
 }
 
 export default ErrorWarning

--- a/src/js/components/ErrorWarning.jsx
+++ b/src/js/components/ErrorWarning.jsx
@@ -1,0 +1,48 @@
+import React from 'react'
+
+export function renderHeader(props) {
+  switch(props.error.httpStatus) {
+    case 403:
+    return 'You have been automatically logged out.'
+
+    case 404:
+    return 'Sorry, there is an unrecoverable problem with this filing.'
+
+    case 500:
+    return 'Sorry, there\'s a problem on our end.'
+
+    default:
+    return 'Sorry, an error has occurred.'
+  }
+}
+
+export function renderBody(props) {
+  switch(props.error.httpStatus) {
+    case 403:
+    return 'Please refresh the page to log in again.'
+
+    case 404:
+    return 'Please upload your file again.'
+
+    case 500:
+    return 'We\'re quickly on resolving the issue. Please try again soon.'
+
+    default:
+    return 'Please refresh the page. If this message persists, you will need to upload your file again.'
+  }
+}
+
+const ErrorWarning = (props) => {
+  if(!props.error) return null
+
+  return (
+    <div className="ErrorWarning usa-alert usa-alert-error">
+      <div className="usa-alert-body">
+        <h3 className="usa-alert-heading">{renderHeader(props)}</h3>
+        <p className="usa-alert-text">{renderBody(props)}</p>
+      </div>
+    </div>
+  )
+}
+
+export default ErrorWarning

--- a/src/js/components/ErrorWarning.jsx
+++ b/src/js/components/ErrorWarning.jsx
@@ -1,6 +1,8 @@
 import React from 'react'
 
 export function renderHeader(props) {
+  if(props.headerText) return props.headerText
+
   switch(props.error.httpStatus) {
     case 403:
     return 'You have been automatically logged out.'
@@ -17,6 +19,8 @@ export function renderHeader(props) {
 }
 
 export function renderBody(props) {
+  if(props.bodyText) return props.bodyText
+
   switch(props.error.httpStatus) {
     case 403:
     return 'Please refresh the page to log in again.'

--- a/src/js/components/Institutions.jsx
+++ b/src/js/components/Institutions.jsx
@@ -2,6 +2,7 @@ import React, {Component, PropTypes} from 'react'
 import {Link} from 'react-router'
 import Header from './Header.jsx'
 import LoadingIcon from './LoadingIcon.jsx'
+import ErrorWarning from './ErrorWarning.jsx'
 import RefileButton from '../containers/RefileButton.jsx'
 import moment from 'moment'
 
@@ -191,6 +192,7 @@ export default class Institution extends Component {
         pathname={this.props.location.pathname}
         userName={this.props.user.profile.name} />
       <div id="main-content" className="usa-grid">
+        {this.props.error ? <ErrorWarning error={this.props.error}/> : null}
         <div className="usa-width-two-thirds">
           {this.props.isFetching || !this.props.filings ?
             <div className="usa-grid-full">

--- a/src/js/components/Signature.jsx
+++ b/src/js/components/Signature.jsx
@@ -14,8 +14,19 @@ const showReceipt = (code, timestamp, receipt) => {
   )
 }
 
-const showWarning = (code) => {
-  if(code > 8) return null
+const showWarning = (props) => {
+  if(!props.error && props.status.code > 8) return null
+
+  if(props.error) {
+    return (
+      <div className="usa-alert usa-alert-error">
+        <div className="usa-alert-body">
+          <h3 className="usa-alert-heading">An error has occurred.</h3>
+          <p className="usa-alert-text">You cannot sign your submission if you have encountered an error in the filing process. Please refresh the page or try again later.</p>
+        </div>
+      </div>
+    )
+  }
 
   return (
     <div className="usa-alert usa-alert-warning">
@@ -28,20 +39,26 @@ const showWarning = (code) => {
 }
 
 const Signature = (props) => {
-  // if code greater than 8 (validated) and not 12 (signed), enable the checkbox
-  const isDisabled = (props.status.code > 8 && props.status.code !== 11) ? false : true
+  // if code greater than 8 (validated) and not 11 (signed), enable the checkbox
+  let isDisabled = (props.status.code > 8 && props.status.code !== 11) ? false : true
 
   let buttonClass = 'usa-button-disabled'
   // if the checkbox is checked remove disabled from button
   if(props.checked) {
     buttonClass = ''
   }
-  // if code is 12 (signed), disable button again
+  // if code is 11 (signed), disable button again
   if(props.status.code === 11) {
     buttonClass = 'usa-button-disabled'
   }
 
-  const headingClass = props.status.code === 11 ? 'text-green' : 'text-secondary'
+  // if an error has occurred, disable both checkbox and button
+  if(props.error) {
+    isDisabled = true
+    buttonClass = 'usa-button-disabled'
+  }
+
+  const headingClass = props.status.code === 11 && !props.error ? 'text-green' : 'text-secondary'
 
   return (
     <div className="Signature" id="signature">
@@ -50,7 +67,7 @@ const Signature = (props) => {
         <p className="usa-font-lead">To complete your submission first check the checkbox to certify accuracy and then click the button to sign.</p>
       </header>
 
-      {showWarning(props.status.code)}
+      {showWarning(props)}
 
       <ul className="usa-unstyled-list">
         <li>

--- a/src/js/components/Signature.jsx
+++ b/src/js/components/Signature.jsx
@@ -1,4 +1,5 @@
 import React, { Component, PropTypes } from 'react'
+import ErrorWarning from './ErrorWarning.jsx'
 import moment from 'moment'
 
 const showReceipt = (code, timestamp, receipt) => {
@@ -17,16 +18,12 @@ const showReceipt = (code, timestamp, receipt) => {
 const showWarning = (props) => {
   if(!props.error && props.status.code > 8) return null
 
-  if(props.error) {
-    return (
-      <div className="usa-alert usa-alert-error">
-        <div className="usa-alert-body">
-          <h3 className="usa-alert-heading">An error has occurred.</h3>
-          <p className="usa-alert-text">You cannot sign your submission if you have encountered an error in the filing process. Please refresh the page or try again later.</p>
-        </div>
-      </div>
-    )
-  }
+  if(props.error) return (
+    <ErrorWarning
+      error={props.error}
+      bodyText="You cannot sign your submission if you have encountered an error in the filing process. Please refresh the page or try again later."
+    />
+  )
 
   return (
     <div className="usa-alert usa-alert-warning">

--- a/src/js/constants/index.js
+++ b/src/js/constants/index.js
@@ -1,3 +1,4 @@
+export const RECEIVE_ERROR          = 'RECEIVE_ERROR'
 export const REFRESH_STATE          = 'REFRESH_STATE'
 
 export const RECEIVE_AUTH_USER      = 'RECEIVE_AUTH_USER'

--- a/src/js/containers/Institutions.jsx
+++ b/src/js/containers/Institutions.jsx
@@ -32,11 +32,14 @@ export function mapStateToProps(state) {
 
   const user = state.oidc && state.oidc.user || null
 
+  const error = state.app.error
+
   return {
     isFetching,
     institutions,
     filings,
-    user
+    user,
+    error
   }
 }
 

--- a/src/js/containers/Signature.jsx
+++ b/src/js/containers/Signature.jsx
@@ -39,12 +39,15 @@ export function mapStateToProps(state) {
     }
   }
 
+  const error = state.app.error
+
   return {
     isFetching,
     timestamp,
     receipt,
     status,
-    checked
+    checked,
+    error
   }
 }
 

--- a/src/js/containers/Submission.jsx
+++ b/src/js/containers/Submission.jsx
@@ -10,6 +10,7 @@ import Header from '../components/Header.jsx'
 import UserHeading from '../components/UserHeading.jsx'
 import UploadForm from './UploadForm.jsx'
 import Edits from './Edits.jsx'
+import ErrorWarning from '../components/ErrorWarning.jsx'
 import EditsNavComponent from '../components/EditsNav.jsx'
 import NavButtonComponent from '../components/NavButton.jsx'
 import RefileWarningComponent  from '../components/RefileWarning.jsx'
@@ -110,6 +111,7 @@ class SubmissionContainer extends Component {
         </div>
       </div>
       <div id="main-content" className="usa-grid">
+        {this.props.error ? <ErrorWarning error={this.props.error}/> : null }
         <div className="usa-width-one-whole">
           {toRender.map((component, i) => {
             return <div key={i}>{component}</div>
@@ -131,11 +133,14 @@ function mapStateToProps(state) {
 
   const institution = state.app.institution
 
+  const error = state.app.error
+
   return {
     isFetching,
     status,
     user,
-    institution
+    institution,
+    error
   }
 }
 

--- a/src/js/reducers/index.js
+++ b/src/js/reducers/index.js
@@ -1,5 +1,6 @@
 import { combineReducers } from 'redux'
 import {
+  RECEIVE_ERROR,
   REFRESH_STATE,
   REQUEST_INSTITUTION,
   RECEIVE_INSTITUTION,
@@ -107,10 +108,26 @@ const defaultPagination = {
   parseErrors: null
 }
 
+const defaultError = null
+
 
 //empty action logger, temporary / for debugging
 export const auth = (state = {}, action) => {
   return state
+}
+
+
+export const error = (state = defaultError, action) => {
+  switch(action.type) {
+    case RECEIVE_ERROR:
+    return action.error
+
+    case REFRESH_STATE:
+    return defaultError
+
+    default:
+    return state
+  }
 }
 
 
@@ -474,5 +491,6 @@ export default combineReducers({
   signature,
   summary,
   parseErrors,
-  pagination
+  pagination,
+  error
 })

--- a/src/sass/app.scss
+++ b/src/sass/app.scss
@@ -14,6 +14,7 @@
 
 // Components
 @import "components/Home.scss";
+@import "components/ErrorWarning.scss";
 @import "components/Pagination.scss";
 @import "components/LoadingIcon.scss";
 @import "components/RefileButton.scss";

--- a/src/sass/components/ErrorWarning.scss
+++ b/src/sass/components/ErrorWarning.scss
@@ -1,0 +1,3 @@
+.ErrorWarning {
+  margin: 2em 0;
+}


### PR DESCRIPTION
Closes #431 

Picks out 403, 404, and 500 for special error messages. These can be adjusted as needed.

An error existing only prevents signing, if desired this could be extended to verification in a similar manner.