### PR TITLE
Sign

### DIFF
--- a/__tests__/components/Signature.js
+++ b/__tests__/components/Signature.js
@@ -9,7 +9,7 @@ import TestUtils from 'react-addons-test-utils'
 const fs = require('fs')
 const signJSON = JSON.parse(fs.readFileSync('./__tests__/json/receipt.json'))
 const status = {
-  code: 10,
+  code: 9,
   message: ''
 }
 
@@ -18,7 +18,14 @@ describe('Signature component', () => {
   const onSignatureCheck = jest.fn()
   const signature = TestUtils.renderIntoDocument(
     <Wrapper>
-      <Signature checked={false} receipt={signJSON.receipt} timestamp={signJSON.timestamp} status={status} onSignatureClick={onSignatureClick} onSignatureCheck={onSignatureCheck}/>
+      <Signature
+        checked={false}
+        receipt={signJSON.receipt}
+        timestamp={signJSON.timestamp}
+        status={status}
+        onSignatureClick={onSignatureClick}
+        onSignatureCheck={onSignatureCheck}
+      />
     </Wrapper>
   )
   const signatureNode = ReactDOM.findDOMNode(signature)
@@ -59,7 +66,14 @@ describe('Signature component', () => {
  // button enabled
   const buttonEnabled = TestUtils.renderIntoDocument(
     <Wrapper>
-      <Signature checked={true} receipt={signJSON.receipt} timestamp={signJSON.timestamp} status={status} onSignatureClick={onSignatureClick} onSignatureCheck={onSignatureCheck}/>
+      <Signature
+        checked={true}
+        receipt={signJSON.receipt}
+        timestamp={signJSON.timestamp}
+        status={status}
+        onSignatureClick={onSignatureClick}
+        onSignatureCheck={onSignatureCheck}
+      />
     </Wrapper>
   )
   const buttonEnabledNode = ReactDOM.findDOMNode(buttonEnabled)
@@ -78,12 +92,19 @@ describe('Signature component', () => {
 
   // checkbox checked and status is signed
   const statusSigned = {
-    code: 11,
+    code: 10,
     message: ''
   }
   const signatureSigned = TestUtils.renderIntoDocument(
     <Wrapper>
-      <Signature checked={true} receipt={signJSON.receipt} timestamp={signJSON.timestamp} status={statusSigned} onSignatureClick={onSignatureClick} onSignatureCheck={onSignatureCheck}/>
+      <Signature
+        checked={true}
+        receipt={signJSON.receipt}
+        timestamp={signJSON.timestamp}
+        status={statusSigned}
+        onSignatureClick={onSignatureClick}
+        onSignatureCheck={onSignatureCheck}
+      />
     </Wrapper>
   )
   const signatureSignedNode = ReactDOM.findDOMNode(signatureSigned)
@@ -112,7 +133,14 @@ describe('Signature component', () => {
   }
   const signatureWithEdits = TestUtils.renderIntoDocument(
     <Wrapper>
-      <Signature checked={true} receipt={signJSON.receipt} timestamp={signJSON.timestamp} status={statusEdits} onSignatureClick={onSignatureClick} onSignatureCheck={onSignatureCheck}/>
+      <Signature
+        checked={true}
+        receipt={signJSON.receipt}
+        timestamp={signJSON.timestamp}
+        status={statusEdits}
+        onSignatureClick={onSignatureClick}
+        onSignatureCheck={onSignatureCheck}
+      />
     </Wrapper>
   )
   const signatureWithEditsNode = ReactDOM.findDOMNode(signatureWithEdits)

--- a/src/js/actions/index.js
+++ b/src/js/actions/index.js
@@ -281,13 +281,7 @@ export function fetchIRS() {
     return getIRS(latestSubmissionId)
       .then(json => {
         if(hasHttpError(json)) throw new Error(JSON.stringify(dispatch(receiveError(json))))
-        dispatch(receiveIRS(json))
-        return dispatch(updateStatus(
-          {
-            code: json.status.code,
-            message: json.status.message
-          }
-        ))
+        return dispatch(receiveIRS(json))
       })
       .catch(err => console.error(err))
   }

--- a/src/js/components/Signature.jsx
+++ b/src/js/components/Signature.jsx
@@ -3,7 +3,7 @@ import ErrorWarning from './ErrorWarning.jsx'
 import moment from 'moment'
 
 const showReceipt = (code, timestamp, receipt) => {
-  if(code !== 11) return null;
+  if(code !== 10) return null;
 
   return (
     <div className="usa-alert usa-alert-success">
@@ -36,16 +36,16 @@ const showWarning = (props) => {
 }
 
 const Signature = (props) => {
-  // if code greater than 8 (validated) and not 11 (signed), enable the checkbox
-  let isDisabled = (props.status.code > 8 && props.status.code !== 11) ? false : true
+  // if code greater than 8 (validated) and not 10 (signed), enable the checkbox
+  let isDisabled = (props.status.code > 8 && props.status.code !== 10) ? false : true
 
   let buttonClass = 'usa-button-disabled'
   // if the checkbox is checked remove disabled from button
   if(props.checked) {
     buttonClass = ''
   }
-  // if code is 11 (signed), disable button again
-  if(props.status.code === 11) {
+  // if code is 10 (signed), disable button again
+  if(props.status.code === 10) {
     buttonClass = 'usa-button-disabled'
   }
 
@@ -55,7 +55,7 @@ const Signature = (props) => {
     buttonClass = 'usa-button-disabled'
   }
 
-  const headingClass = props.status.code === 11 && !props.error ? 'text-green' : 'text-secondary'
+  const headingClass = props.status.code === 10 && !props.error ? 'text-green' : 'text-secondary'
 
   return (
     <div className="Signature" id="signature">


### PR DESCRIPTION
Closes #442 

Also removes the update status from the `fetchIRS` action, that endpoint doesn't return a status anymore.

If you want to test this in the UI you'll have to update the `fetchSignature` action. You'll have to change the `dispatch(updateStatus)` to:

```javascript
return dispatch(updateStatus(
  {
    code: 9,
    message: 'validated'
  }
))
```

This is because we aren't getting a validated status after the edits have been verified.