### PR TITLE
Better polling

### DIFF
--- a/__tests__/actions/actions.js
+++ b/__tests__/actions/actions.js
@@ -335,9 +335,16 @@ describe('actions', () => {
       })
   })
 
+  it('does not poll on pages other than upload', () => {
+    expect(actions.pollForProgress()()).toBe(undefined)
+  })
   it('creates a thunk that will poll for updated status codes in the latest submission', done => {
     const store = mockStore({submission: {}})
     const submission = filingsObj.submissions[2]
+
+    delete global.location
+    global.location = {pathname: '/upload'}
+
     store.dispatch(actions.pollForProgress()).then(() => {
         expect(store.getActions()).toEqual([
           {

--- a/__tests__/components/UploadForm.js
+++ b/__tests__/components/UploadForm.js
@@ -14,6 +14,8 @@ import TestUtils from 'react-addons-test-utils'
 describe('submitform', function(){
   const handleSubmit = jest.fn()
   const setFile = jest.fn()
+  const pollSubmission = jest.fn()
+  const poll2 = jest.fn()
 
   // use ReactDOM.render instead to be able to test componentDidUpdate
   const node = document.createElement('div')
@@ -21,6 +23,7 @@ describe('submitform', function(){
       <Wrapper>
         <UploadForm
           handleSubmit={handleSubmit}
+          pollSubmission={pollSubmission}
           setFile={setFile}
           uploading={true}
           file={{size:108}}
@@ -40,6 +43,10 @@ describe('submitform', function(){
     expect(input.value).toEqual('')
   })
 
+  it('calls the poll', () => {
+    expect(pollSubmission).toBeCalled()
+  })
+
   it('submits the form', function(){
     TestUtils.Simulate.submit(
       TestUtils.findRenderedDOMComponentWithTag(form, 'form')
@@ -51,7 +58,9 @@ describe('submitform', function(){
   const form2 = ReactDOM.render(
       <Wrapper>
         <UploadForm
+          pollSubmission={poll2}
           handleSubmit={handleSubmit}
+          code={1}
           setFile={setFile}
           uploading={true}
           file={{size:200}}
@@ -62,6 +71,10 @@ describe('submitform', function(){
   it('expects the file input to be empty', () => {
     const input = TestUtils.scryRenderedDOMComponentsWithTag(form2, 'input')[0]
     expect(input.value).toEqual('')
+  })
+
+  it('does not call the poll', () => {
+    expect(poll2).not.toBeCalled()
   })
 })
 

--- a/src/js/actions/index.js
+++ b/src/js/actions/index.js
@@ -562,7 +562,7 @@ export function pollForProgress() {
       })
       .then(json => {
         if(json.status.code < 8 && json.status.code !== 5){
-          setTimeout(() => poller(dispatch), 500)
+          setTimeout(() => poller(dispatch), 1000)
         }
       })
       .catch(err => console.error(err))

--- a/src/js/actions/index.js
+++ b/src/js/actions/index.js
@@ -554,6 +554,7 @@ export function fetchSubmission() {
 
 export function pollForProgress() {
   const poller = dispatch => {
+    if(!location.pathname.match('/upload')) return
     return getLatestSubmission()
       .then(json => {
         if(hasHttpError(json)) throw new Error(JSON.stringify(dispatch(receiveError(json))))

--- a/src/js/components/UploadForm.jsx
+++ b/src/js/components/UploadForm.jsx
@@ -57,6 +57,7 @@ export default class Upload extends Component {
   // keeps the info about the file after leaving /upload and coming back
   componentDidMount() {
     renderDropText(this.props, this.dropzoneContent)
+      if(this.props.code > 2) this.props.pollSubmission()
   }
 
   render() {
@@ -123,6 +124,7 @@ Upload.propTypes = {
   setFile: PropTypes.func,
   setNewFile: PropTypes.func,
   showConfirmModal: PropTypes.func,
+  pollSubmission: PropTypes.func,
   uploading: PropTypes.bool,
   file: PropTypes.object,
   code: PropTypes.number,

--- a/src/js/containers/Submission.jsx
+++ b/src/js/containers/Submission.jsx
@@ -38,7 +38,7 @@ const renderByCode = (code, page, message) => {
         toRender.push(<ParseErrors />)
       }
     }else if(['syntacticalvalidity','quality','macro'].indexOf(page) !== -1){
-      if(code > 6){
+      if(code > 7){
         if(code === 8) toRender.push(<RefileWarning />)
         toRender.push(<Edits />)
       }
@@ -74,6 +74,7 @@ class SubmissionContainer extends Component {
       this.props.dispatch(fetchSubmission())
     }
 
+    // for institution name in header
     this.props.dispatch(fetchInstitution(institution, false))
   }
 

--- a/src/js/containers/SubmissionRouter.jsx
+++ b/src/js/containers/SubmissionRouter.jsx
@@ -33,7 +33,7 @@ export class SubmissionRouter extends Component {
       )
     }
 
-    if(code < 7) return browserHistory.replace(pathname + '/upload')
+    if(code < 8) return browserHistory.replace(pathname + '/upload')
 
     if(code < 10) return browserHistory.replace(pathname + '/syntacticalvalidity')
 

--- a/src/js/containers/UploadForm.jsx
+++ b/src/js/containers/UploadForm.jsx
@@ -5,7 +5,8 @@ import {
   selectNewFile,
   requestUpload,
   createNewSubmission,
-  showConfirm
+  showConfirm,
+  pollForProgress
 } from '../actions'
 
 export function mapStateToProps(state) {
@@ -56,6 +57,10 @@ export function mapDispatchToProps(dispatch) {
 
     showConfirmModal: (id, filing, code) => {
       dispatch(showConfirm(id, filing, code))
+    },
+
+    pollSubmission: () => {
+      dispatch(pollForProgress())
     }
   }
 }


### PR DESCRIPTION
Two main pieces of this PR:
 - Stops polling on non-upload pages
 - Restarts polling when upload page is visited while parsing/validation is in progress