### PR TITLE
Don't render tables for macro

### DIFF
--- a/__tests__/components/EditsTable.js
+++ b/__tests__/components/EditsTable.js
@@ -31,6 +31,16 @@ describe('Edits Table', () => {
     expect(tableNode).toBeDefined()
   })
 
+  const editsTableMacro = TestUtils.renderIntoDocument(
+    <Wrapper><EditsTable edits={types.macro.edits[0]} type='macro'/></Wrapper>
+  )
+
+  const macroNode = ReactDOM.findDOMNode(editsTableMacro)
+
+  it('renders the table', () => {
+    expect(macroNode).toBeDefined()
+    expect(TestUtils.scryRenderedDOMComponentsWithTag(editsTableMacro, 'table').length).toBe(0)
+  })
   const editsTableNoEdits = TestUtils.renderIntoDocument(
     <Wrapper><EditsTable type='syntactical'/></Wrapper>
   )
@@ -84,12 +94,6 @@ describe('renderHeader', () => {
     expect(rendered.props.children[1].props.children).toBe('Agency Code')
   })
 
-  it('renders header with macro', () => {
-    const edits = types.macro.edits
-    const rendered = renderHeader(edits, rows, 'macro')
-    expect(rendered.type).toBe('tr')
-    expect(rendered.props.children[0].props.children).toBe('Agency Code')
-  })
 })
 
 describe('renderBody', () => {
@@ -123,11 +127,17 @@ describe('renderBody', () => {
 })
 
 describe('renderTableCaption', () => {
-  it('renders the caption with a description', () => {
+  it('renders the syntactical caption with a description', () => {
     const edits = types.syntactical.edits[0]
-    const rendered = renderTableCaption(edits, {rows: rows}, {S020:{total:3}})
+    const rendered = renderTableCaption(edits, {rows: rows}, 'syntactical', {S020:{total:3}})
     expect(rendered.type).toBe('caption')
     expect(rendered.props.children[0].props.children).toBe('3 S020 edits found.')
+  })
+
+  it('renders the macro caption as a div', () => {
+    const edits = types.macro.edits[0]
+    const rendered = renderTableCaption(edits, {rows: rows}, 'macro', {Q008: {total:1}})
+    expect(rendered.type).toBe('div')
   })
 
   it('returns null without a name', () => {

--- a/src/js/components/EditsTable.jsx
+++ b/src/js/components/EditsTable.jsx
@@ -19,8 +19,6 @@ export const renderHeader = (edits, rows, type) => {
   let keyCells = rows[0].row
   const fieldCells = rows[0].fields
 
-  if(type === 'macro') keyCells = {}
-
   const numOfCells = Object.keys(keyCells).length + Object.keys(fieldCells).length
   const cellWidth = `${100/numOfCells}%`
 
@@ -37,11 +35,11 @@ export const renderHeader = (edits, rows, type) => {
 
 export const renderBody = (edits, rows, type) => {
   return rows.map((row, i) => {
-    return <EditsTableRow row={type === 'macro' ? {} : row.row} fields={row.fields} key={i}/>
+    return <EditsTableRow row={row.row} fields={row.fields} key={i}/>
   })
 }
 
-export const renderTableCaption = (edit, rowObj, pagination) => {
+export const renderTableCaption = (edit, rowObj, type, pagination) => {
   const name = edit.edit
   if(!name) return null
 
@@ -52,8 +50,17 @@ export const renderTableCaption = (edit, rowObj, pagination) => {
   const editText = length === 1 ? 'edit' : 'edits'
   const captionHeader = `${length} ${name} ${editText} found.`
 
+  if(type === 'macro') {
+    return (
+      <div className="caption">
+        <h3>{captionHeader}</h3>
+        {description ? <p className="usa-font-lead">{description}</p>:null}
+      </div>
+    )
+  }
+
   return (
-    <caption>
+    <caption className="caption">
       <h3>{captionHeader}</h3>
       {description ? <p className="usa-font-lead">{description}</p>:null}
     </caption>
@@ -62,20 +69,23 @@ export const renderTableCaption = (edit, rowObj, pagination) => {
 
 export const makeTable = (props) => {
   const edit = props.edit
+  const type = props.type
   const rowObj = props.rows[edit.edit]
 
   if(!rowObj || rowObj.isFetching) return <LoadingIcon/>
 
   return (
-  <table width="100%">
-    {renderTableCaption(edit, rowObj, props.pagination)}
-    <thead>
-      {renderHeader(edit, rowObj.rows, props.type)}
-    </thead>
-    <tbody>
-      {renderBody(edit, rowObj.rows, props.type)}
-    </tbody>
-  </table>
+  type === 'macro'
+  ? renderTableCaption(edit, rowObj, type, props.pagination)
+  : <table width="100%">
+      {renderTableCaption(edit, rowObj, type, props.pagination)}
+      <thead>
+        {renderHeader(edit, rowObj.rows, type)}
+      </thead>
+      <tbody>
+        {renderBody(edit, rowObj.rows, type)}
+      </tbody>
+    </table>
   )
 }
 
@@ -86,7 +96,7 @@ const EditsTable = (props) => {
   return (
     <div className="EditsTable">
       {makeTable(props)}
-      <Pagination target={props.edit.edit}/>
+      {props.type === 'macro' ? null : <Pagination target={props.edit.edit}/>}
     </div>
   )
 }


### PR DESCRIPTION
Closes #489 

The separation of edits in #468 will be especially important for macro now (as such I've essentially ignored the styling of the macro page in this PR)