### PR TITLE
Edits nav edits independence

### DIFF
--- a/__tests__/components/EditsTableWrapper.js
+++ b/__tests__/components/EditsTableWrapper.js
@@ -19,10 +19,10 @@ const types = {
 describe('EditsTableWrapper', () => {
   const onDownloadClick = jest.fn()
 
-  it('renders 4 children if type is quality and typeFromPath is quality', () => {
+  it('renders 4 children if type is quality and page is quality', () => {
     const rendered = EditsTableWrapper({
       onDownloadClick: onDownloadClick,
-      editTypeFromPath: 'quality',
+      page: 'quality',
       pagination: {},
       rows: {
         S020: {

--- a/src/js/components/EditsNav.jsx
+++ b/src/js/components/EditsNav.jsx
@@ -54,14 +54,11 @@ const getNavClass = (name, props) => {
         }
       }
       break
-    case 'summary':
-      if(code > 7) {
-        if(!syntacticalValidityEditsExist && qualityVerified && macroVerified) navClass = 'active'
-      }
   }
 
-  // catch all if signed
-  if(code === 10) navClass = 'complete'
+  // catch all if validated
+  if(code > 8) navClass = 'complete'
+  if(code === 9 && name === 'summary') navClass = 'active'
   // add current class if page matches the name
   if(name === page) navClass = `${navClass} current`
 
@@ -109,15 +106,16 @@ const renderLinkOrText = (props, name, i) => {
   // only render link when code > 7 (so it's finished validating)
   if(code > 7) {
     toRender = <Link className="usa-nav-link"  to={`${base}/${navLinks[name]}`}>{name}</Link>
-
-    if(syntacticalValidityEditsExist && navNames.indexOf(name) > 1) {
-      toRender = <span>{name}</span>
-    }
-    if(!qualityVerified && navNames.indexOf(name) > 2) {
-      toRender = <span>{name}</span>
-    }
-    if(!macroVerified && navNames.indexOf(name) > 3) {
-      toRender = <span>{name}</span>
+    if(code < 9) {
+      if(syntacticalValidityEditsExist && navNames.indexOf(name) > 1) {
+        toRender = <span>{name}</span>
+      }
+      if(!qualityVerified && navNames.indexOf(name) > 2) {
+        toRender = <span>{name}</span>
+      }
+      if(!macroVerified && navNames.indexOf(name) > 3) {
+        toRender = <span>{name}</span>
+      }
     }
   } else {
     toRender = <span>{name}</span>

--- a/src/js/components/EditsTableWrapper.jsx
+++ b/src/js/components/EditsTableWrapper.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { browserHistory } from 'react-router'
 import EditsHeaderDescription from './EditsHeaderDescription.jsx'
 import LoadingIcon from './LoadingIcon.jsx'
 import EditsTable from './EditsTable.jsx'
@@ -32,7 +33,14 @@ export const renderTables = (props, edits, type) => {
 }
 
 const EditsTableWrapper = (props) => {
-  const type = props.editTypeFromPath
+  const type = props.page
+  if(props.fetched &&
+    (type === 'macro' || type === 'quality') &&
+    props.syntacticalValidityEditsExist) {
+      setTimeout(()=>browserHistory.replace(props.base + '/syntacticalvalidity'),0)
+      return null
+  }
+
   return props.isFetching
   ? <LoadingIcon/>
   : <div className="EditsContainerBody">

--- a/src/js/containers/Edits.jsx
+++ b/src/js/containers/Edits.jsx
@@ -1,7 +1,10 @@
 import React, { Component } from 'react'
 import { connect } from 'react-redux'
-import EditsTableWrapper from '../components/EditsTableWrapper.jsx'
+import submissionProgressHOC from './submissionProgressHOC.jsx'
+import Wrapper from '../components/EditsTableWrapper.jsx'
 import { fetchEdits } from '../actions'
+
+const EditsTableWrapper = submissionProgressHOC(Wrapper)
 
 export class EditsContainer extends Component {
   constructor(props) {
@@ -29,7 +32,6 @@ export function mapStateToProps(state) {
     rows
   } = state.app.edits
 
-  const editTypeFromPath = state.routing.locationBeforeTransitions.pathname.split('/').slice(-1)[0]
   const {
     pagination
   } = state.app
@@ -39,7 +41,6 @@ export function mapStateToProps(state) {
     fetched,
     types,
     rows,
-    editTypeFromPath,
     pagination
   }
 }

--- a/src/js/containers/Submission.jsx
+++ b/src/js/containers/Submission.jsx
@@ -9,8 +9,8 @@ import HomeLink from '../components/HomeLink.jsx'
 import Header from '../components/Header.jsx'
 import UserHeading from '../components/UserHeading.jsx'
 import UploadForm from './UploadForm.jsx'
-import Edits from './Edits.jsx'
 import ErrorWarning from '../components/ErrorWarning.jsx'
+import EditsContainer from './Edits.jsx'
 import EditsNavComponent from '../components/EditsNav.jsx'
 import NavButtonComponent from '../components/NavButton.jsx'
 import RefileWarningComponent  from '../components/RefileWarning.jsx'
@@ -22,6 +22,7 @@ import RefileButton from '../containers/RefileButton.jsx'
 import ParseErrors from './ParseErrors.jsx'
 import LoadingIcon from '../components/LoadingIcon.jsx'
 
+const Edits = submissionProgressHOC(EditsContainer)
 const EditsNav = submissionProgressHOC(EditsNavComponent)
 const NavButton = submissionProgressHOC(NavButtonComponent)
 const RefileWarning = submissionProgressHOC(RefileWarningComponent)

--- a/src/js/containers/SubmissionRouter.jsx
+++ b/src/js/containers/SubmissionRouter.jsx
@@ -52,13 +52,14 @@ export class SubmissionRouter extends Component {
 
     if(code < 8 || splat === 'upload' ) return this.replaceHistory('upload')
 
-    if(code < 10) {
+    if(code === 8) {
       if(editTypes.includes(splat)) {
         return this.forceUpdate()
       }
       return this.replaceHistory('syntacticalvalidity')
     }
 
+    if(splat) return this.forceUpdate()
     return this.replaceHistory('summary')
   }
 

--- a/src/js/containers/SubmissionRouter.jsx
+++ b/src/js/containers/SubmissionRouter.jsx
@@ -1,7 +1,10 @@
 import React, { Component, PropTypes } from 'react'
 import { connect } from 'react-redux'
 import { browserHistory } from 'react-router'
+import SubmissionContainer from './Submission.jsx'
 import { fetchSubmission } from '../actions'
+
+const editTypes = ['syntacticalvalidity', 'quality', 'macro']
 
 export class SubmissionRouter extends Component {
   constructor(props) {
@@ -9,20 +12,34 @@ export class SubmissionRouter extends Component {
   }
 
   componentDidMount() {
-    this.props.dispatch(fetchSubmission())
-      .then((json) => {
-        this.route(this.props)
-      })
+    this.renderChildren = false
+    if(!this.props.status || this.props.status.code === 0) {
+      this.props.dispatch(fetchSubmission())
+        .then((json) => {
+          this.route()
+        })
+    } else {
+      this.route()
+    }
   }
 
-  route(props) {
-    if(!props.user) return null
-    if(!props.status) return null
+  replaceHistory(splat) {
+    const { institution, filing } = this.props.params
+    return browserHistory.replace(
+      `/${institution}/${filing}/${splat}`
+    )
+  }
 
-    const status = props.status
+  route() {
+    if(!this.props.user) return null
+    if(!this.props.status) return null
+
+
+    const status = this.props.status
     const code = status.code
-    const pathname= props.pathname
+    const splat = this.props.params.splat
 
+    this.renderChildren = true
   // status codes can be found at https://github.com/cfpb/hmda-platform/blob/master/Documents/submission-status.md
 
     if(code === -1){
@@ -33,15 +50,27 @@ export class SubmissionRouter extends Component {
       )
     }
 
-    if(code < 8) return browserHistory.replace(pathname + '/upload')
+    if(code < 8 || splat === 'upload' ) return this.replaceHistory('upload')
 
-    if(code < 10) return browserHistory.replace(pathname + '/syntacticalvalidity')
+    if(code < 10) {
+      if(editTypes.includes(splat)) {
+        return this.forceUpdate()
+      }
+      return this.replaceHistory('syntacticalvalidity')
+    }
 
-    return browserHistory.replace(pathname + '/summary')
+    return this.replaceHistory('summary')
   }
 
   render() {
-    return null
+    if(!this.props.status || this.props.status.code === 0) return null
+    if(!this.renderChildren) return null
+    if(!this.props.params.splat) {
+      setTimeout(()=>this.replaceHistory('upload'),0)
+      return null
+    }
+
+    return <SubmissionContainer {...this.props}/>
   }
 }
 
@@ -53,17 +82,13 @@ export function mapStateToProps(state, ownProps) {
   }
 
   const user = state.oidc && state.oidc.user || null
-  const pathname = ownProps.location.pathname
+  const params = ownProps.params
 
   return {
     status,
     user,
-    pathname
+    params
   }
-}
-
-SubmissionRouter.propTypes = {
-  dispatch: PropTypes.func.isRequired
 }
 
 SubmissionRouter.defaultProps = {
@@ -71,4 +96,4 @@ SubmissionRouter.defaultProps = {
   status: null
 }
 
-export default connect(mapStateToProps)(SubmissionRouter)
+export default connect(mapStateToProps, dispatch => {return {dispatch}})(SubmissionRouter)

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -34,7 +34,7 @@ fetch('/env.json').then(res => {
   const userManager = UserManager()
   setUserManager(userManager)
   const oidcMiddleware = createOidcMiddleware(userManager, () => false, false, '/oidc-callback')
-  const loggerMiddleware = createLogger()
+  const loggerMiddleware = createLogger({collapsed: true})
 
   const store = createStore(
     combineReducers(
@@ -66,7 +66,7 @@ fetch('/env.json').then(res => {
             <Route path="/oidc-callback" component={oidcCallback}/>
             <Route path="/institutions" component={InstitutionContainer}/>
             <Route path="/:institution/:filing" component={SubmissionRouter}/>
-            <Route path="/:institution/:filing/*" component={SubmissionContainer}/>
+            <Route path="/:institution/:filing/*" component={SubmissionRouter}/>
           </Route>
         </Router>
       </OidcProvider>


### PR DESCRIPTION
Closes #476 

Also, routes away from pages that shouldn't be viewable based on app state (eg, the summary page before all edits are verified or macro edits when synval exist). These weren't linked in the app at the wrong times, but still could be visited via URL (and could have possibly led to confusing situations if users attempted to bookmark pages across submissions).