### PR TITLE
Home page and nav updates

### DIFF
--- a/__tests__/components/Header.js
+++ b/__tests__/components/Header.js
@@ -1,7 +1,7 @@
 jest.unmock('../../src/js/components/Header.jsx')
 jest.mock('oidc-client')
 
-import Header from '../../src/js/components/Header.jsx'
+import Header, { addActiveClass } from '../../src/js/components/Header.jsx'
 import Wrapper from '../Wrapper.js'
 import React from 'react'
 import ReactDOM from 'react-dom'
@@ -22,8 +22,8 @@ describe('Header', () => {
     expect(headerNode).toBeDefined()
   })
 
-  it('render the logout link', () => {
-    expect(TestUtils.scryRenderedDOMComponentsWithClass(header, 'logout').length).toBe(1)
+  it('render the institutions link', () => {
+    expect(TestUtils.scryRenderedDOMComponentsWithClass(header, 'nav-institutions').length).toBe(1)
   })
 
   const headerNoUser = TestUtils.renderIntoDocument(
@@ -34,7 +34,19 @@ describe('Header', () => {
     </Wrapper>
   )
 
-  it('render the login link', () => {
+  it('renders the login link', () => {
     expect(TestUtils.scryRenderedDOMComponentsWithClass(headerNoUser, 'usa-button').length).toBe(1)
+  })
+
+  describe('addActiveClass', () => {
+    it('returns the correct style', () => {
+      const returned = addActiveClass('upload', 'upload')
+      expect(returned).toEqual('active')
+    })
+
+    it('returns null', () => {
+      const returned = addActiveClass('upload', 'notupload')
+      expect(returned).toEqual(null)
+    })
   })
 })

--- a/__tests__/components/Header.js
+++ b/__tests__/components/Header.js
@@ -1,7 +1,7 @@
 jest.unmock('../../src/js/components/Header.jsx')
 jest.mock('oidc-client')
 
-import Header, { styleSelectedPage } from '../../src/js/components/Header.jsx'
+import Header from '../../src/js/components/Header.jsx'
 import Wrapper from '../Wrapper.js'
 import React from 'react'
 import ReactDOM from 'react-dom'
@@ -37,17 +37,4 @@ describe('Header', () => {
   it('render the login link', () => {
     expect(TestUtils.scryRenderedDOMComponentsWithClass(headerNoUser, 'usa-button').length).toBe(1)
   })
-})
-
-describe('styleSelectedPage', () => {
-  it('returns the correct style', () => {
-    const returned = styleSelectedPage('upload', 'upload')
-    expect(returned).toEqual({"borderBottom": "2px solid"})
-  })
-
-  it('returns an empty object', () => {
-    const returned = styleSelectedPage('upload', 'notupload')
-    expect(returned).toEqual({})
-  })
-
 })

--- a/src/js/components/Header.jsx
+++ b/src/js/components/Header.jsx
@@ -3,29 +3,7 @@ import { Link } from 'react-router'
 import { signinRedirect, logout } from '../redirect.js'
 import BannerUSA from './BannerUSA.jsx'
 
-export const styleSelectedPage = (selected, current) => {
-  if(selected === current) return {borderBottom: '2px solid'}
-  return {}
-}
-
-export const renderLoggedInNav = (props) => {
-  if(!props.userName) return null
-  return (
-    <nav role="navigation" className="Header usa-nav">
-      <ul className="usa-nav-primary">
-        <li>
-          <Link className="usa-nav-link" style={styleSelectedPage(page, '')} to={'/'}>Home</Link>
-        </li>
-        <li>
-          <Link className="usa-button usa-button-outline" to={'/institutions'}>Institutions</Link>
-        </li>
-      </ul>
-    </nav>
-  )
-}
-
 const Header = (props) => {
-  const page = props.pathname.split('/').slice(-1)[0]
   return (
     <header className="usa-header usa-header-basic" role="banner">
       <BannerUSA />
@@ -44,7 +22,7 @@ const Header = (props) => {
           ?
           <ul className="usa-nav-primary">
             <li>
-              <Link className="usa-nav-link" style={styleSelectedPage(page, '')} to={'/'}>Home</Link>
+              <Link className="usa-nav-link" to={'/'}>Home</Link>
             </li>
             <li>
               <Link className="usa-button usa-button-outline" to={'/institutions'}>Institutions</Link>
@@ -66,8 +44,7 @@ const Header = (props) => {
 }
 
 Header.propTypes = {
-  userName: React.PropTypes.string,
-  pathname: React.PropTypes.string
+  userName: React.PropTypes.string
 }
 
 export default Header

--- a/src/js/components/Header.jsx
+++ b/src/js/components/Header.jsx
@@ -25,7 +25,7 @@ const Header = (props) => {
               <Link className="usa-nav-link" to={'/'}>Home</Link>
             </li>
             <li>
-              <Link className="usa-button usa-button-outline" to={'/institutions'}>Institutions</Link>
+              <Link className="usa-button usa-button-outline" to={'/institutions'}>My Institutions</Link>
             </li>
             <li className="logout">{props.userName} - <a className="usa-nav-link" href="#" onClick={(e) => {
                e.preventDefault()

--- a/src/js/components/Header.jsx
+++ b/src/js/components/Header.jsx
@@ -12,7 +12,7 @@ const Header = (props) => {
   const page = props.pathname.split('/').slice(-1)[0]
 
   return (
-    <header className="usa-header usa-header-basic" role="banner">
+    <header className="Header usa-header usa-header-basic" role="banner">
       <BannerUSA />
       <div className="usa-nav-container">
         <div className="usa-logo" id="logo">
@@ -24,7 +24,7 @@ const Header = (props) => {
               aria-label="Home">HMDA Filing</Link>
           </em>
         </div>
-        <nav role="navigation" className="Header usa-nav">
+        <nav role="navigation" className="usa-nav">
           {props.userName
           ?
           <ul className="usa-nav-primary">
@@ -41,7 +41,7 @@ const Header = (props) => {
           </ul>
           :
           <ul className="usa-nav-primary">
-            <li><Link to={'/institutions'} className="usa-button">Login</Link></li>
+            <li><Link to="/institutions" className="usa-button">Login</Link></li>
           </ul>
           }
         </nav>

--- a/src/js/components/Header.jsx
+++ b/src/js/components/Header.jsx
@@ -3,7 +3,14 @@ import { Link } from 'react-router'
 import { signinRedirect, logout } from '../redirect.js'
 import BannerUSA from './BannerUSA.jsx'
 
+export const addActiveClass = (selected, current) => {
+  if(selected === current) return 'active'
+  return null
+}
+
 const Header = (props) => {
+  const page = props.pathname.split('/').slice(-1)[0]
+
   return (
     <header className="usa-header usa-header-basic" role="banner">
       <BannerUSA />
@@ -21,13 +28,13 @@ const Header = (props) => {
           {props.userName
           ?
           <ul className="usa-nav-primary">
-            <li>
-              <Link className="usa-nav-link" to={'/'}>Home</Link>
+            <li>{props.userName}</li>
+            <li className="nav-institutions">
+              <Link
+                className={`usa-nav-link ${addActiveClass(page, 'institutions')}`}
+                to="/institutions">My Institutions</Link>
             </li>
-            <li>
-              <Link className="usa-button usa-button-outline" to={'/institutions'}>My Institutions</Link>
-            </li>
-            <li className="logout">{props.userName} - <a className="usa-nav-link" href="#" onClick={(e) => {
+            <li><a className="usa-nav-link" href="#" onClick={(e) => {
                e.preventDefault()
                logout()
              }}>Logout</a></li>
@@ -44,7 +51,8 @@ const Header = (props) => {
 }
 
 Header.propTypes = {
-  userName: React.PropTypes.string
+  userName: React.PropTypes.string,
+  pathname: React.PropTypes.string
 }
 
 export default Header

--- a/src/js/components/Header.jsx
+++ b/src/js/components/Header.jsx
@@ -15,7 +15,13 @@ const Header = (props) => {
       <BannerUSA />
       <div className="usa-nav-container">
         <div className="usa-logo" id="logo">
-          <img src="/img/ffiec-logo.png" width="90px"/>
+          <em className="usa-logo-text">
+            <Link
+              className="usa-nav-link"
+              to={'/'}
+              title="Home"
+              aria-label="Home">HMDA Filing</Link>
+          </em>
         </div>
         <nav role="navigation" className="Header usa-nav usa-nav-left">
           <ul className="usa-nav-primary">

--- a/src/js/components/Header.jsx
+++ b/src/js/components/Header.jsx
@@ -23,16 +23,6 @@ const Header = (props) => {
               aria-label="Home">HMDA Filing</Link>
           </em>
         </div>
-        <nav role="navigation" className="Header usa-nav usa-nav-left">
-          <ul className="usa-nav-primary">
-            <li>
-              <Link className="usa-nav-link" style={styleSelectedPage(page, '')} to={'/'}>Home</Link>
-            </li>
-            <li>
-              <Link className="usa-nav-link" style={styleSelectedPage(page, 'institutions')} to={'/institutions'}>Institutions</Link>
-            </li>
-          </ul>
-        </nav>
         <nav role="navigation" className="Header usa-nav">
           <ul className="usa-nav-primary">
             {props.userName
@@ -47,6 +37,16 @@ const Header = (props) => {
                 signinRedirect(true)
               }}>Login</a></li>
             }
+          </ul>
+        </nav>
+        <nav role="navigation" className="Header usa-nav">
+          <ul className="usa-nav-primary">
+            <li>
+              <Link className="usa-nav-link" style={styleSelectedPage(page, '')} to={'/'}>Home</Link>
+            </li>
+            <li>
+              <Link className="usa-nav-link" style={styleSelectedPage(page, 'institutions')} to={'/institutions'}>Institutions</Link>
+            </li>
           </ul>
         </nav>
       </div>

--- a/src/js/components/Header.jsx
+++ b/src/js/components/Header.jsx
@@ -8,6 +8,13 @@ export const styleSelectedPage = (selected, current) => {
   return {}
 }
 
+export const renderInstitutionLink = (props) => {
+  if(!props.userName) return null
+  return <li>
+    <Link className="usa-button usa-button-outline" to={'/institutions'}>Institutions</Link>
+  </li>
+}
+
 const Header = (props) => {
   const page = props.pathname.split('/').slice(-1)[0]
   return (
@@ -44,9 +51,7 @@ const Header = (props) => {
             <li>
               <Link className="usa-nav-link" style={styleSelectedPage(page, '')} to={'/'}>Home</Link>
             </li>
-            <li>
-              <Link className="usa-nav-link" style={styleSelectedPage(page, 'institutions')} to={'/institutions'}>Institutions</Link>
-            </li>
+            {renderInstitutionLink(props)}
           </ul>
         </nav>
       </div>

--- a/src/js/components/Header.jsx
+++ b/src/js/components/Header.jsx
@@ -8,11 +8,20 @@ export const styleSelectedPage = (selected, current) => {
   return {}
 }
 
-export const renderInstitutionLink = (props) => {
+export const renderLoggedInNav = (props) => {
   if(!props.userName) return null
-  return <li>
-    <Link className="usa-button usa-button-outline" to={'/institutions'}>Institutions</Link>
-  </li>
+  return (
+    <nav role="navigation" className="Header usa-nav">
+      <ul className="usa-nav-primary">
+        <li>
+          <Link className="usa-nav-link" style={styleSelectedPage(page, '')} to={'/'}>Home</Link>
+        </li>
+        <li>
+          <Link className="usa-button usa-button-outline" to={'/institutions'}>Institutions</Link>
+        </li>
+      </ul>
+    </nav>
+  )
 }
 
 const Header = (props) => {
@@ -31,28 +40,25 @@ const Header = (props) => {
           </em>
         </div>
         <nav role="navigation" className="Header usa-nav">
-          <ul className="usa-nav-primary">
-            {props.userName
-            ?
-              <li className="logout">{props.userName} - <a className="usa-nav-link" href="#" onClick={(e) => {
-               e.preventDefault()
-               logout()
-             }}>Logout</a></li>
-            :
-              <li><a className="usa-button" href="#" onClick={(e) => {
-                e.preventDefault()
-                signinRedirect(true)
-              }}>Login</a></li>
-            }
-          </ul>
-        </nav>
-        <nav role="navigation" className="Header usa-nav">
+          {props.userName
+          ?
           <ul className="usa-nav-primary">
             <li>
               <Link className="usa-nav-link" style={styleSelectedPage(page, '')} to={'/'}>Home</Link>
             </li>
-            {renderInstitutionLink(props)}
+            <li>
+              <Link className="usa-button usa-button-outline" to={'/institutions'}>Institutions</Link>
+            </li>
+            <li className="logout">{props.userName} - <a className="usa-nav-link" href="#" onClick={(e) => {
+               e.preventDefault()
+               logout()
+             }}>Logout</a></li>
           </ul>
+          :
+          <ul className="usa-nav-primary">
+            <li><Link to={'/institutions'} className="usa-button">Login</Link></li>
+          </ul>
+          }
         </nav>
       </div>
     </header>

--- a/src/js/components/Home.jsx
+++ b/src/js/components/Home.jsx
@@ -37,11 +37,14 @@ const Home = (props) => {
             <div className="usa-width-one-whole">
               <h2>Get started filing your HMDA data</h2>
               <p className="usa-font-lead">Beginning with HMDA data collected in or after 2017, financial institutions will use the HMDA Platform to upload their loan/application registers (LARs), review edits, certify the accuracy and completeness of the data, and submit data for the filing year.</p>
-              <Link
+              <a href="#"
                 className="usa-button"
-                to="/institutions">
+                onClick={(e) => {
+                  e.preventDefault()
+                  signinRedirect(true)
+                }}>
                 {props.user.profile.name ? 'Begin Filing' : 'Get Started Filing'}
-              </Link>
+              </a>
               <p className="usa-text-small">Every user is required to register online for login credentials and establish an account prior to accessing the HMDA Platform.</p>
             </div>
           </div>

--- a/src/js/components/Home.jsx
+++ b/src/js/components/Home.jsx
@@ -24,32 +24,45 @@ const getLoginMessage = (userName) => {
   )
 }
 
+const renderLoggedInHero = () => {
+  return (
+    <section className="usa-hero">
+      <div className="usa-grid">
+        <div className="usa-width-one-whole">
+          <h2>View your institutions</h2>
+          <p className="usa-font-lead">The institutions page provides a summary of institutions for which you are authorized to file HMDA data. The filing status is displayed under the institution name.</p>
+          <Link to={'/institutions'} className="usa-button">Back to Your Institutions</Link>
+        </div>
+      </div>
+    </section>
+  )
+  //
+}
+
+const renderLoggedOutHero = () => {
+  return (
+    <section className="usa-hero">
+      <div className="usa-grid">
+        <div className="usa-width-one-whole">
+          <h2>Get started filing your HMDA data</h2>
+          <p className="usa-font-lead">Beginning with HMDA data collected in or after 2017, financial institutions will use the HMDA Platform to upload their loan/application registers (LARs), review edits, certify the accuracy and completeness of the data, and submit data for the filing year.</p>
+          <Link to={'/institutions'} className="usa-button">Get Started Filing</Link>
+          <p className="usa-text-small">Every user is required to register online for login credentials and establish an account prior to accessing the HMDA Platform.</p>
+        </div>
+      </div>
+    </section>
+  )
+}
+
 const Home = (props) => {
+  const renderHero = props.user.profile.name ? renderLoggedInHero() : renderLoggedOutHero()
   return (
     <div>
       <Header
         pathname={props.location.pathname}
         userName={props.user.profile.name} />
       <div className="Home" id="main-content">
-        {/*getLoginMessage(props.user.profile.name)*/}
-        <section className="usa-hero">
-          <div className="usa-grid">
-            <div className="usa-width-one-whole">
-              <h2>Get started filing your HMDA data</h2>
-              <p className="usa-font-lead">Beginning with HMDA data collected in or after 2017, financial institutions will use the HMDA Platform to upload their loan/application registers (LARs), review edits, certify the accuracy and completeness of the data, and submit data for the filing year.</p>
-              <a href="#"
-                className="usa-button"
-                onClick={(e) => {
-                  e.preventDefault()
-                  signinRedirect(true)
-                }}>
-                {props.user.profile.name ? 'Begin Filing' : 'Get Started Filing'}
-              </a>
-              <p className="usa-text-small">Every user is required to register online for login credentials and establish an account prior to accessing the HMDA Platform.</p>
-            </div>
-          </div>
-        </section>
-
+        {renderHero}
         <div className="usa-grid">
           <div className="usa-width-seven-twelfths">
             <div className="faqs">

--- a/src/js/components/Home.jsx
+++ b/src/js/components/Home.jsx
@@ -58,9 +58,7 @@ const Home = (props) => {
   const renderHero = props.user.profile.name ? renderLoggedInHero() : renderLoggedOutHero()
   return (
     <div>
-      <Header
-        pathname={props.location.pathname}
-        userName={props.user.profile.name} />
+      <Header userName={props.user.profile.name} />
       <div className="Home" id="main-content">
         {renderHero}
         <div className="usa-grid">

--- a/src/js/components/Home.jsx
+++ b/src/js/components/Home.jsx
@@ -56,9 +56,12 @@ const renderLoggedOutHero = () => {
 
 const Home = (props) => {
   const renderHero = props.user.profile.name ? renderLoggedInHero() : renderLoggedOutHero()
+  
   return (
     <div>
-      <Header userName={props.user.profile.name} />
+      <Header
+        pathname={props.location.pathname}
+        userName={props.user.profile.name} />
       <div className="Home" id="main-content">
         {renderHero}
         <div className="usa-grid">

--- a/src/js/components/Home.jsx
+++ b/src/js/components/Home.jsx
@@ -29,9 +29,9 @@ const renderLoggedInHero = () => {
     <section className="usa-hero">
       <div className="usa-grid">
         <div className="usa-width-one-whole">
-          <h2>View your institutions</h2>
-          <p className="usa-font-lead">The institutions page provides a summary of institutions for which you are authorized to file HMDA data. The filing status is displayed under the institution name.</p>
-          <Link to={'/institutions'} className="usa-button">Back to Your Institutions</Link>
+          <h2>Thanks for logging in!</h2>
+          <p className="usa-font-lead">The place to get started is the institutions page. This page provides a summary of institutions for which you are authorized to file HMDA data, along with the current filing status, access to previous submission data (CSV), and the ability to continue filing or start over.</p>
+          <Link to={'/institutions'} className="usa-button">View Your Institutions</Link>
         </div>
       </div>
     </section>

--- a/src/js/components/Home.jsx
+++ b/src/js/components/Home.jsx
@@ -31,66 +31,52 @@ const Home = (props) => {
         pathname={props.location.pathname}
         userName={props.user.profile.name} />
       <div className="Home" id="main-content">
-        {getLoginMessage(props.user.profile.name)}
+        {/*getLoginMessage(props.user.profile.name)*/}
+        <section className="usa-hero">
+          <div className="usa-grid">
+            <div className="usa-width-one-whole">
+              <h2>Get started filing your HMDA data</h2>
+              <p className="usa-font-lead">Beginning with HMDA data collected in or after 2017, financial institutions will use the HMDA Platform to upload their loan/application registers (LARs), review edits, certify the accuracy and completeness of the data, and submit data for the filing year.</p>
+              <Link
+                className="usa-button"
+                to="/institutions">
+                {props.user.profile.name ? 'Begin Filing' : 'Get Started Filing'}
+              </Link>
+              <p className="usa-text-small">Every user is required to register online for login credentials and establish an account prior to accessing the HMDA Platform.</p>
+            </div>
+          </div>
+        </section>
 
         <div className="usa-grid">
-          <div className="usa-width-one-half">
-            <p className="usa-font-lead">Beginning with HMDA data collected in or after 2017, financial institutions will use the HMDA Platform to upload their loan/application registers (LARs), review edits, certify the accuracy and completeness of the data, and submit data for the filing year.</p>
-            <p>For resources to help you prepare your HMDA filing, please visit <a href="http://www.consumerfinance.gov/data-research/hmda/for-filers">Resources for HMDA filers</a>.</p>
-            <h3>How to get started</h3>
-            <p>Select the login button to begin the process for filing your HMDA data. Every user is required to register online for login credentials and establish an account prior to accessing the HMDA Platform.</p>
-            <p>Once you have logged in, select the Institutions link above to access your institution(s). The HMDA Platform will then guide you through the filing process.</p>
-            <Link
-              className="usa-button"
-              to="/institutions">
-              {props.user.profile.name ? 'Begin Filing' : 'Login and Begin Filing'}
-            </Link>
+          <div className="usa-width-seven-twelfths">
+            <div className="faqs">
+              <h3>Top FAQs</h3>
+              <dl>
+                <dt>What type of browser do I need in order to use the CFPB’s HMDA Platform?</dt>
+                <dd>We recommend that HMDA filers use a modern browser, such as the latest version of Google Chrome or Mozilla Firefox, Internet Explorer 11, Microsoft Edge, or other modern browsers.</dd>
+                <dt>What is the deadline for submitting my HMDA data?</dt>
+                <dd>The deadline for submitting HMDA data is March 1 following the calendar year for which data are collected and recorded. For example, for data collected in 2017, the deadline for submitting HMDA data is March 1, 2018.</dd>
+                <dt>Can my financial institution have multiple user accounts?</dt>
+                <dd>Each financial institution may have multiple users. Also, a user may be authorized by more than one financial institution to file HMDA data on those institutions’ behalf, provided that under Regulation C, each such institution is a HMDA filer.</dd>
+                <dt>Will I be able to manually enter my LAR into the HMDA Platform?</dt>
+                <dd>The HMDA Platform only accepts a pipe delimited text file containing your LAR. Any modifications to the data must be updated in the file and uploaded to the HMDA Platform. This must be a single file as the HMDA Platform will not allow users to combine multiple files.</dd>
+                <dt>Is there another tool for me to confirm that my LAR is in the correct format?</dt>
+                <dd>Filers who wish to confirm that their LAR is formatted in the required pipe delimited text file format may use the <a href="https://github.com/cfpb/hmda-platform-tools">File Format Verification Tool</a>. This tool will conduct the same initial checks that the HMDA Platform performs, and provides a convenient test mechanism for filers.</dd>
+              </dl>
+            </div>
           </div>
-          <div className="usa-width-one-half">
-            <h3>Top FAQs</h3>
-            <dl>
-              <dt>What type of browser do I need in order to use the CFPB’s HMDA Platform?</dt>
-              <dd>We recommend that HMDA filers use a modern browser, such as the latest version of Google Chrome or Mozilla Firefox, Internet Explorer 11, Microsoft Edge, or other modern browsers.</dd>
-              <dt>What is the deadline for submitting my HMDA data?</dt>
-              <dd>The deadline for submitting HMDA data is March 1 following the calendar year for which data are collected and recorded. For example, for data collected in 2017, the deadline for submitting HMDA data is March 1, 2018.</dd>
-              <dt>Can my financial institution have multiple user accounts?</dt>
-              <dd>Each financial institution may have multiple users. Also, a user may be authorized by more than one financial institution to file HMDA data on those institutions’ behalf, provided that under Regulation C, each such institution is a HMDA filer.</dd>
-              <dt>Will I be able to manually enter my LAR into the HMDA Platform?</dt>
-              <dd>The HMDA Platform only accepts a pipe delimited text file containing your LAR. Any modifications to the data must be updated in the file and uploaded to the HMDA Platform. This must be a single file as the HMDA Platform will not allow users to combine multiple files.</dd>
-              <dt>Is there another tool for me to confirm that my LAR is in the correct format?</dt>
-              <dd>Filers who wish to confirm that their LAR is formatted in the required pipe delimited text file format may use the <a href="https://github.com/cfpb/hmda-platform-tools">File Format Verification Tool</a>. This tool will conduct the same initial checks that the HMDA Platform performs, and provides a convenient test mechanism for filers.</dd>
-            </dl>
-          </div>
-        </div>
+          <div className="usa-width-five-twelfths">
+            <div className="resources">
+              <h3>Resources</h3>
 
-        <div className="usa-grid">
-          <hr />
-          <div className="usa-width-one-fourth">
-            <h4>1003 Regulation C</h4>
-            <ul className="usa-unstyled-list">
-              <li><a href="http://www.consumerfinance.gov/eregulations/1003">Home Mortgage Disclosure</a></li>
-            </ul>
-          </div>
-
-          <div className="usa-width-one-fourth">
-            <h4>Tools</h4>
-            <ul className="usa-unstyled-list">
-              <li><a href="https://github.com/cfpb/hmda-platform-tools">File Format Verification Tool</a></li>
-            </ul>
-          </div>
-
-          <div className="usa-width-one-fourth">
-            <h4>FFIEC</h4>
-            <ul className="usa-unstyled-list">
-              <li><a href="https://www.ffiec.gov/hmda/">HMDA</a></li>
-            </ul>
-          </div>
-
-          <div className="usa-width-one-fourth">
-            <h4>Data Publication</h4>
-            <ul className="usa-unstyled-list">
-              <li><a href="#">Modified LAR</a></li>
-            </ul>
+              <ul>
+                <li><a href="http://www.consumerfinance.gov/eregulations/1003">1003 Regulation C - Home Mortgage Disclosure</a></li>
+                <li><a href="http://www.consumerfinance.gov/data-research/hmda/for-filers">Help preparing your HMDA filing</a></li>
+                <li><a href="https://github.com/cfpb/hmda-platform-tools">File Format Verification Tool</a></li>
+                <li><a href="https://www.ffiec.gov/hmda/">FFIEC/HMDA</a></li>
+                <li><a href="#">Modified LAR</a></li>
+              </ul>
+            </div>
           </div>
         </div>
 

--- a/src/js/components/Home.jsx
+++ b/src/js/components/Home.jsx
@@ -73,7 +73,7 @@ const Home = (props) => {
                 <li><a href="http://www.consumerfinance.gov/eregulations/1003">1003 Regulation C - Home Mortgage Disclosure</a></li>
                 <li><a href="http://www.consumerfinance.gov/data-research/hmda/for-filers">Help preparing your HMDA filing</a></li>
                 <li><a href="https://github.com/cfpb/hmda-platform-tools">File Format Verification Tool</a></li>
-                <li><a href="https://www.ffiec.gov/hmda/">FFIEC/HMDA</a></li>
+                <li><a href="https://www.ffiec.gov/hmda/">FFIEC - HMDA</a></li>
                 <li><a href="#">Modified LAR</a></li>
               </ul>
             </div>

--- a/src/js/components/Institutions.jsx
+++ b/src/js/components/Institutions.jsx
@@ -190,9 +190,7 @@ export default class Institution extends Component {
     const makeNewSubmission = this.props.makeNewSubmission
     return (
     <div>
-      <Header
-        pathname={this.props.location.pathname}
-        userName={this.props.user.profile.name} />
+      <Header userName={this.props.user.profile.name} />
       <div id="main-content" className="usa-grid Institutions">
         {this.props.error ? <ErrorWarning error={this.props.error}/> : null}
         <div className="usa-width-one-half">

--- a/src/js/components/Institutions.jsx
+++ b/src/js/components/Institutions.jsx
@@ -190,7 +190,9 @@ export default class Institution extends Component {
     const makeNewSubmission = this.props.makeNewSubmission
     return (
     <div>
-      <Header userName={this.props.user.profile.name} />
+      <Header
+        pathname={this.props.location.pathname}
+        userName={this.props.user.profile.name} />
       <div id="main-content" className="usa-grid Institutions">
         {this.props.error ? <ErrorWarning error={this.props.error}/> : null}
         <div className="usa-width-one-half">

--- a/src/js/components/Institutions.jsx
+++ b/src/js/components/Institutions.jsx
@@ -189,11 +189,11 @@ export default class Institution extends Component {
     const institutions = this.props.institutions
     const makeNewSubmission = this.props.makeNewSubmission
     return (
-    <div className="Institutions">
+    <div>
       <Header
         pathname={this.props.location.pathname}
         userName={this.props.user.profile.name} />
-      <div id="main-content" className="usa-grid">
+      <div id="main-content" className="usa-grid Institutions">
         {this.props.error ? <ErrorWarning error={this.props.error}/> : null}
         <div className="usa-width-one-half">
           <div className="InstitutionsHeader">

--- a/src/js/containers/App.jsx
+++ b/src/js/containers/App.jsx
@@ -30,7 +30,7 @@ export class AppContainer extends Component {
               <nav className="usa-footer-nav usa-width-one-half">
                 <ul className="usa-unstyled-list">
                   <li className="usa-footer-primary-content">
-                    <a className="usa-footer-primary-link" href="https://www.ffiec.gov/">FFIEC</a>
+                    <a className="usa-footer-primary-link" href="https://www.ffiec.gov/"><img src="/img/ffiec-logo.png" width="100px"/></a>
                   </li>
                 </ul>
               </nav>

--- a/src/js/containers/Submission.jsx
+++ b/src/js/containers/Submission.jsx
@@ -96,12 +96,12 @@ class SubmissionContainer extends Component {
 
 
     return (
-    <div className="SubmissionContainer">
+    <div>
       <Header
         pathname={location.pathname}
         userName={user.profile.name}
       />
-      <div className="usa-grid">
+      <div className="usa-grid SubmissionContainer">
         <div className="usa-width-one-whole">
           <UserHeading
             period={params.filing}

--- a/src/js/containers/Submission.jsx
+++ b/src/js/containers/Submission.jsx
@@ -97,10 +97,7 @@ class SubmissionContainer extends Component {
 
     return (
     <div>
-      <Header
-        pathname={location.pathname}
-        userName={user.profile.name}
-      />
+      <Header userName={user.profile.name} />
       <div className="usa-grid SubmissionContainer">
         <div className="usa-width-one-whole">
           <UserHeading

--- a/src/js/containers/Submission.jsx
+++ b/src/js/containers/Submission.jsx
@@ -97,7 +97,9 @@ class SubmissionContainer extends Component {
 
     return (
     <div>
-      <Header userName={user.profile.name} />
+      <Header
+        pathname={location.pathname}
+        userName={user.profile.name} />
       <div className="usa-grid SubmissionContainer">
         <div className="usa-width-one-whole">
           <UserHeading

--- a/src/sass/app.scss
+++ b/src/sass/app.scss
@@ -3,6 +3,7 @@
 
 // HDMA customizations to USWDS
 @import "uswds/header.scss";
+@import "uswds/hero.scss";
 @import "uswds/alert.scss";
 @import "uswds/footer.scss";
 @import "uswds/fixes.scss";

--- a/src/sass/app.scss
+++ b/src/sass/app.scss
@@ -20,6 +20,7 @@
 @import "components/NavButton.scss";
 @import "components/ConfirmationModal.scss";
 @import "components/Institutions.scss";
+@import "components/Submission.scss";
 @import "components/IRSReport.scss";
 @import "components/RefileWarning.scss";
 @import "components/RefileText.scss";

--- a/src/sass/components/Home.scss
+++ b/src/sass/components/Home.scss
@@ -24,4 +24,10 @@
     margin-bottom: 2em;
   }
 
+  .resources {
+    border-left: 1px solid $color-gray-lightest;
+    float: right;
+    padding-left: 1em;
+  }
+
 }

--- a/src/sass/components/Institutions.scss
+++ b/src/sass/components/Institutions.scss
@@ -1,3 +1,6 @@
+.Institutions {
+  margin-top: 4em;
+}
 .institution {
   margin-bottom: 3em;
 

--- a/src/sass/components/Submission.scss
+++ b/src/sass/components/Submission.scss
@@ -1,0 +1,3 @@
+.SubmissionContainer {
+  margin-top: 4em;
+}

--- a/src/sass/uswds/header.scss
+++ b/src/sass/uswds/header.scss
@@ -77,6 +77,9 @@
         color: $color-white;
         background-color: $color-primary-darker;
       }
+      &.usa-button-outline:hover {
+        color: $color-white
+      }
     }
   }
 

--- a/src/sass/uswds/header.scss
+++ b/src/sass/uswds/header.scss
@@ -1,7 +1,6 @@
 .usa-header {
   background-color: $color-white;
   border-bottom: 1px solid $color-gray-lighter;
-  margin-bottom: 3em;
 }
 
 .usa-navbar {
@@ -24,17 +23,21 @@
 
 .usa-header-basic .usa-logo {
   bottom: 0;
+  font-weight: bold;
+  margin-top: 3px;
   position: relative;
 }
 
 .usa-banner-inner {
   padding-top: .25em;
   padding-bottom: .25em;
+  max-width: 100%;
 }
 
 .usa-nav-container {
   padding-top: .5em;
   padding-bottom: .5em;
+  max-width: 100%;
 }
 
 .usa-nav-secondary-links {

--- a/src/sass/uswds/header.scss
+++ b/src/sass/uswds/header.scss
@@ -54,7 +54,7 @@
   font-size: 1.3rem;
   margin-left: 0;
 
-  &.logout {
+  &.nav-institutions {
     margin-left: 3em;
     &>a.usa-nav-link{
       margin-left: 0;
@@ -67,6 +67,10 @@
     margin: 1.3rem 1.5rem 1rem;
     padding: 0;
     text-transform: uppercase;
+
+    &.active {
+      border-bottom: 2px solid;
+    }
 
     &.usa-button {
       color: $color-white;

--- a/src/sass/uswds/hero.scss
+++ b/src/sass/uswds/hero.scss
@@ -1,8 +1,8 @@
 .usa-hero {
   background-color: $color-gray-lightest;
   background-image: none;
-  padding-top: 12em;
-  padding-bottom: 12em;
+  padding-top: 8em;
+  padding-bottom: 8em;
 
   h2 {
     margin: 0;

--- a/src/sass/uswds/hero.scss
+++ b/src/sass/uswds/hero.scss
@@ -1,0 +1,19 @@
+.usa-hero {
+  background-color: $color-gray-lightest;
+  background-image: none;
+  padding-top: 12em;
+  padding-bottom: 12em;
+
+  h2 {
+    margin: 0;
+  }
+  p {
+    margin-bottom: 0;
+    &.usa-font-lead {
+      margin-top: 0;
+    }
+  }
+  .usa-button {
+    margin-top: 2em;
+  }
+}


### PR DESCRIPTION
Closes #487 

- adds a "hero" section to the home page to bring a focus to getting logged in
- always redirects to the institutions page after login
  - this seems to be a more useful location to end up (the home page isn't very useful when the goal is filing
- removes navigation for institutions until logged in as well, when logged in this link is highlighted more by being a button (outlined button)
- moves logo to footer and replaces it with "HMDA filing" in the header

### Screenshots

#### New home page (no real navigation, but we could add an FAQ page)

![new-home](https://cloud.githubusercontent.com/assets/2932572/25291582/a2997bfc-26a0-11e7-8a30-36f51971f746.png)

---

#### Navigation after login

![new-nav](https://cloud.githubusercontent.com/assets/2932572/25291595/b604136e-26a0-11e7-99d7-87143bfbba5c.png)

---

#### New home page after login (to show that it still exists, we can/should update this content too)

![new-home-logged-in](https://cloud.githubusercontent.com/assets/2932572/25291604/c153570c-26a0-11e7-934e-80a9f929717d.png)


