### PR TITLE
Auto-redirect from fetch

### DIFF
--- a/src/js/api/fetch.js
+++ b/src/js/api/fetch.js
@@ -3,6 +3,7 @@ import createQueryString from './createQueryString.js'
 import parseLocation from './parseLocation.js'
 import makeUrl from './makeUrl.js'
 import * as AccessToken from './AccessToken.js'
+import { signinRedirect } from '../utils/redirect.js'
 
 export function fetch(options = {method: 'GET'}){
   const accessToken = AccessToken.get()
@@ -42,6 +43,7 @@ export function fetch(options = {method: 'GET'}){
 
   return isomorphicFetch(url, fetchOptions)
     .then(response => {
+      if(response.status === 401) signinRedirect()
       if(options.params && options.params.format === 'csv') {
         return response.text()
       }


### PR DESCRIPTION
Closes #538 

If met with 401s (SSO token expired, unable to silent renew), any failed request will redirect the oidc-callback page to refresh the token. This will fail if the session expiration has been reached (but this defaults to 8 hrs, so not something we should be strictly concerned about).