### PR TITLE
Smooth auth flows / make auth state more consistent

### DIFF
--- a/__tests__/utils/redirect.js
+++ b/__tests__/utils/redirect.js
@@ -27,7 +27,7 @@ describe('redirect', () => {
     expect(console.error.mock.calls.length).toBe(1)
   })
 
-  it('calls redir but short circuits based pathname', () => {
+  it('calls redir', () => {
     const um = jest.fn()
     const ls = jest.fn()
 
@@ -37,19 +37,17 @@ describe('redirect', () => {
     window.localStorage = {setItem: ls}
     window.location = {pathname: '/'}
 
-    expect(signinRedirect(1)).toBe(true)
-    expect(signinRedirect(0)).toBe(false)
+    expect(signinRedirect()).toBe(undefined)
 
     expect(um.mock.calls.length).toBe(1)
     expect(ls.mock.calls.length).toBe(1)
 
 
     window.location = {pathname: '/oidc-callback'}
-    expect(signinRedirect()).toBe(false)
+    expect(signinRedirect()).toBe(undefined)
 
     window.location = {pathname: '/fake'}
-    expect(signinRedirect()).toBe(true)
-    expect(signinRedirect(1)).toBe(true)
+    expect(signinRedirect()).toBe(undefined)
 
     expect(um.mock.calls.length).toBe(3)
     expect(ls.mock.calls.length).toBe(3)

--- a/src/js/containers/Submission.jsx
+++ b/src/js/containers/Submission.jsx
@@ -75,7 +75,6 @@ class SubmissionContainer extends Component {
   }
 
   render() {
-    if(!this.props.user) return null
     if(!this.props.location) return null
 
     if(!this.props.isFetching &&
@@ -83,7 +82,7 @@ class SubmissionContainer extends Component {
       this.props.dispatch(fetchSubmission())
     }
 
-    const { status, params, user, location } = this.props
+    const { status, params, location } = this.props
     const code = status && status.code
     const page = location.pathname.split('/').slice(-1)[0]
 
@@ -120,8 +119,6 @@ function mapStateToProps(state) {
     status
   } = state.app.submission
 
-  const user = state.oidc && state.oidc.user || null
-
   const institution = state.app.institution
 
   const error = state.app.error
@@ -129,7 +126,6 @@ function mapStateToProps(state) {
   return {
     isFetching,
     status,
-    user,
     institution,
     error
   }

--- a/src/js/containers/SubmissionRouter.jsx
+++ b/src/js/containers/SubmissionRouter.jsx
@@ -31,7 +31,6 @@ export class SubmissionRouter extends Component {
   }
 
   route() {
-    if(!this.props.user) return null
     if(!this.props.status) return null
 
 
@@ -82,18 +81,15 @@ export function mapStateToProps(state, ownProps) {
     status: null
   }
 
-  const user = state.oidc && state.oidc.user || null
   const params = ownProps.params
 
   return {
     status,
-    user,
     params
   }
 }
 
 SubmissionRouter.defaultProps = {
-  user: null,
   status: null
 }
 

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -29,10 +29,11 @@ fetch('/env.json').then(res => {
   window.HMDA_ENV = {}
   Object.keys(envJson).forEach(key => window.HMDA_ENV[key] = envJson[key])
 
-  //oidc.Log.logger = console
+  oidc.Log.logger = console
   const userManager = UserManager()
   setUserManager(userManager)
-  const oidcMiddleware = createOidcMiddleware(userManager, () => false, false, '/oidc-callback')
+  window.userManager = userManager
+  const oidcMiddleware = createOidcMiddleware(userManager, () => true, false, '/oidc-callback')
   const loggerMiddleware = createLogger({collapsed: true})
 
   const store = createStore(

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -33,6 +33,7 @@ fetch('/env.json').then(res => {
   const userManager = UserManager()
   setUserManager(userManager)
   window.userManager = userManager
+  console.log(userManager, userManager.getUser)
   const oidcMiddleware = createOidcMiddleware(userManager, () => true, false, '/oidc-callback')
   const loggerMiddleware = createLogger({collapsed: true})
 

--- a/src/js/reducers/index.js
+++ b/src/js/reducers/index.js
@@ -14,6 +14,7 @@ import summary from './summary.js'
 import parseErrors from './parseErrors.js'
 import pagination from './pagination.js'
 import error from './error.js'
+import user from './user.js'
 
 export default combineReducers({
   institution,
@@ -29,5 +30,6 @@ export default combineReducers({
   summary,
   parseErrors,
   pagination,
-  error
+  error,
+  user
 })

--- a/src/js/reducers/user.js
+++ b/src/js/reducers/user.js
@@ -1,0 +1,20 @@
+const defaultUser = {
+  expired: false
+}
+
+export default (state = defaultUser, action) => {
+  switch (action.type) {
+    case 'redux-oidc/USER_EXPIRED':
+    return {
+      ...state,
+      expired: true
+    }
+    case 'redux-oidc/USER_FOUND':
+    return {
+      ...state,
+      expired: false
+    }
+  default:
+    return state
+  }
+}

--- a/src/js/utils/redirect.js
+++ b/src/js/utils/redirect.js
@@ -10,12 +10,11 @@ const getUserManager = () => {
   return userManager
 }
 
-const signinRedirect = (force) => {
+const signinRedirect = () => {
   if(!userManager) return console.error('userManager needs to be set on app initialization')
   console.log('signinRedirect triggered, saving page:', location.pathname)
   localStorage.setItem('hmdaPageBeforeSignin', location.pathname)
   userManager.signinRedirect()
-  return true
 }
 
 

--- a/src/js/utils/redirect.js
+++ b/src/js/utils/redirect.js
@@ -12,8 +12,6 @@ const getUserManager = () => {
 
 const signinRedirect = (force) => {
   if(!userManager) return console.error('userManager needs to be set on app initialization')
-  if(location.pathname === '/oidc-callback') return false
-  if(!force && location.pathname === '/') return false
   console.log('signinRedirect triggered, saving page:', location.pathname)
   localStorage.setItem('hmdaPageBeforeSignin', location.pathname)
   userManager.signinRedirect()


### PR DESCRIPTION
Closes #553 
Closes #550 

Keys into the user expired/found actions of redux-oidc and uses the `shouldValidate` second argument of redux-oidc's middleware to reauthorize from sessionstorage where possible instead of triggering `signinRedirect`s