### PR TITLE
Content updates

### DIFF
--- a/__tests__/components/EditsTable.js
+++ b/__tests__/components/EditsTable.js
@@ -53,7 +53,7 @@ describe('Edits Table', () => {
 describe('formatHeader', () => {
   it('returns the correct text', () => {
     let header = formatHeader('rowId')
-    expect(header).toBe('Row ID')
+    expect(header).toBe('Loan/Application Number')
 
     header = formatHeader('edit')
     expect(header).toBe('Edit ID')
@@ -74,7 +74,7 @@ describe('renderHeader', () => {
     const edits = types.syntactical.edits[0]
     const rendered = renderHeader(edits, rows, 'syntactical')
     expect(rendered.type).toBe('tr')
-    expect(rendered.props.children[0].props.children).toBe('Row ID')
+    expect(rendered.props.children[0].props.children).toBe('Loan/Application Number')
     expect(rendered.props.children[1].props.children).toBe('Agency Code')
   })
 
@@ -82,7 +82,7 @@ describe('renderHeader', () => {
     const edits = types.validity.edits[0]
     const rendered = renderHeader(edits, rows, 'validity')
     expect(rendered.type).toBe('tr')
-    expect(rendered.props.children[0].props.children).toBe('Row ID')
+    expect(rendered.props.children[0].props.children).toBe('Loan/Application Number')
     expect(rendered.props.children[1].props.children).toBe('Agency Code')
   })
 
@@ -90,7 +90,7 @@ describe('renderHeader', () => {
     const edits = types.quality.edits[0]
     const rendered = renderHeader(edits, rows, 'quality')
     expect(rendered.type).toBe('tr')
-    expect(rendered.props.children[0].props.children).toBe('Row ID')
+    expect(rendered.props.children[0].props.children).toBe('Loan/Application Number')
     expect(rendered.props.children[1].props.children).toBe('Agency Code')
   })
 

--- a/src/js/components/EditsTable.jsx
+++ b/src/js/components/EditsTable.jsx
@@ -4,7 +4,7 @@ import LoadingIcon from './LoadingIcon.jsx'
 import EditsTableRow from './EditsTableRow.jsx'
 
 export const formatHeader = (text) => {
-  if (text === 'rowId') return 'Row ID'
+  if (text === 'rowId') return 'Loan/Application Number'
   if (text === 'edit') return 'Edit ID'
   if (text === 'editId') return 'Edit ID'
   if (text === 'description') return 'Description'

--- a/src/js/components/Summary.jsx
+++ b/src/js/components/Summary.jsx
@@ -20,7 +20,7 @@ const Summary = (props) => {
             <dt>Tax ID:</dt>
             <dd>{props.respondent.taxId}</dd>
             <dt>Agency:</dt>
-            <dd>{props.respondent.agency}</dd>
+            <dd>{props.respondent.agency.toUpperCase()}</dd>
             <dt>Contact Name:</dt>
             <dd>{props.respondent.contact && props.respondent.contact.name}</dd>
             <dt>Phone:</dt>


### PR DESCRIPTION
Closes #554 
Closes #545 

ALLCAPSing the agency on the summary page and rendering `Loan/Application Number` over `Row Id` in the edits tables.