### PR TITLE
Redirect to signin page when silent signin fails

### DIFF
--- a/__tests__/actions/fetchEachInstitution.js
+++ b/__tests__/actions/fetchEachInstitution.js
@@ -39,11 +39,7 @@ const getEachInstitution = [
     type: types.RECEIVE_INSTITUTION,
     institution: institutionsDetailObj['3'].institution
   },
-  {type:types.CLEAR_FILINGS},
-  {type:types.RECEIVE_FILINGS},
-  {type:types.RECEIVE_FILINGS},
-  {type:types.RECEIVE_FILINGS},
-  {type:types.RECEIVE_FILINGS}
+  {type:types.CLEAR_FILINGS}
 ]
 describe('fetchEachInstitution', () => {
   it('creates a thunk that will clear current filings and fetch each institution', done => {

--- a/__tests__/actions/fetchInstitutions.js
+++ b/__tests__/actions/fetchInstitutions.js
@@ -1,5 +1,4 @@
 jest.mock('../../src/js/api/api')
-jest.mock('../../src/js/api/api')
 jest.unmock('../../src/js/actions/fetchInstitutions.js')
 jest.unmock('../../src/js/constants')
 import * as types from '../../src/js/constants'

--- a/__tests__/actions/hasHttpError.js
+++ b/__tests__/actions/hasHttpError.js
@@ -4,10 +4,11 @@ import * as types from '../../src/js/constants'
 import hasHttpError from '../../src/js/actions/hasHttpError.js'
 
 describe('hasHttpError', () => {
-  it('checks for http errors', () => {
-    expect(hasHttpError()).toBe(true)
-    expect(hasHttpError({httpStatus: 401})).toBe(true)
-    expect(hasHttpError({})).toBe(false)
-    expect(hasHttpError({httpStatus: 200})).toBe(false)
+  it('checks for http errors', done => {
+    hasHttpError().then(hasError => expect(hasError).toBe(true))
+    hasHttpError({httpStatus: 401}).then(hasError => done.fail('401 resolves'))
+    hasHttpError({}).then(hasError => expect(hasError).toBe(false))
+    hasHttpError({httpStatus: 200}).then(hasError => expect(hasError).toBe(false))
+    done()
   })
 })

--- a/src/js/actions/fetchCSV.js
+++ b/src/js/actions/fetchCSV.js
@@ -14,8 +14,10 @@ export default function fetchCSV(institutionId, filing, submissionId) {
       submission: submissionId
     })
     .then(csv => {
-      if(hasHttpError(csv)) throw new Error(JSON.stringify(dispatch(receiveError(csv))))
-      return fileSaver.saveAs(new Blob([csv], {type: 'text/csv;charset=utf-16'}), `${submissionId}-full-edit-report.csv`)
+      return hasHttpError(csv).then(hasError => {
+        if(hasError) throw new Error(JSON.stringify(dispatch(receiveError(csv))))
+        return fileSaver.saveAs(new Blob([csv], {type: 'text/csv;charset=utf-16'}), `${submissionId}-full-edit-report.csv`)
+      })
     })
     .catch(err => console.error(err))
   }

--- a/src/js/actions/fetchEachEdit.js
+++ b/src/js/actions/fetchEachEdit.js
@@ -13,8 +13,10 @@ export default function fetchEachEdit(editTypes) {
            dispatch(requestEdit())
            getEdit({submission: getId(), edit: edit.edit})
              .then(json => {
-               if(hasHttpError(json)) throw new Error(JSON.stringify(dispatch(receiveError(json))))
-               dispatch(receiveEdit(json))
+                return hasHttpError(json).then(hasError => {
+                  if(hasError) throw new Error(JSON.stringify(dispatch(receiveError(json))))
+                  return dispatch(receiveEdit(json))
+                })
              })
              .catch(err => console.error(err))
         })

--- a/src/js/actions/fetchEdits.js
+++ b/src/js/actions/fetchEdits.js
@@ -11,10 +11,12 @@ export default function fetchEdits() {
     dispatch(requestEdits())
     return getEdits({submission: getId()})
       .then(json => {
-        if(hasHttpError(json)) throw new Error(JSON.stringify(dispatch(receiveError(json))))
-        dispatch(receiveEdits(json))
-        dispatch(fetchEachEdit(json))
-        return json
+        return hasHttpError(json).then(hasError => {
+          if(hasError) throw new Error(JSON.stringify(dispatch(receiveError(json))))
+          dispatch(receiveEdits(json))
+          dispatch(fetchEachEdit(json))
+          return json
+        })
       })
       .catch(err => console.error(err))
   }

--- a/src/js/actions/fetchFiling.js
+++ b/src/js/actions/fetchFiling.js
@@ -9,8 +9,10 @@ export default function fetchFiling(filing) {
     dispatch(requestFiling())
     return getFiling(filing.institutionId, filing.period)
       .then(json => {
-        if(hasHttpError(json)) throw new Error(JSON.stringify(dispatch(receiveError(json))))
-        return dispatch(receiveFiling(json))
+        return hasHttpError(json).then(hasError => {
+          if(hasError) throw new Error(JSON.stringify(dispatch(receiveError(json))))
+          return dispatch(receiveFiling(json))
+        })
       })
       .catch(err => console.error(err))
   }

--- a/src/js/actions/fetchInstitution.js
+++ b/src/js/actions/fetchInstitution.js
@@ -10,11 +10,13 @@ export default function fetchInstitution(institution, fetchFilings = true) {
     dispatch(requestInstitution())
     return getInstitution(institution.id)
       .then(json => {
-        if(hasHttpError(json)) throw new Error(JSON.stringify(dispatch(receiveError(json))))
-        dispatch(receiveInstitution(json))
-        if(json.filings && fetchFilings){
-          return dispatch(fetchEachFiling(json.filings))
-        }
+        return hasHttpError(json).then(hasError => {
+          if(hasError) throw new Error(JSON.stringify(dispatch(receiveError(json))))
+          dispatch(receiveInstitution(json))
+          if(json.filings && fetchFilings){
+            return dispatch(fetchEachFiling(json.filings))
+          }
+        })
       })
       .catch(err => console.error(err))
   }

--- a/src/js/actions/fetchInstitutions.js
+++ b/src/js/actions/fetchInstitutions.js
@@ -16,7 +16,7 @@ export default function fetchInstitutions() {
         })
       })
       .then(receiveAction => {
-        dispatch(fetchEachInstitution(receiveAction.institutions))
+        return dispatch(fetchEachInstitution(receiveAction.institutions))
       })
       .catch(err => console.error(err))
   }

--- a/src/js/actions/fetchInstitutions.js
+++ b/src/js/actions/fetchInstitutions.js
@@ -10,8 +10,10 @@ export default function fetchInstitutions() {
     dispatch(requestInstitutions())
     return getInstitutions()
       .then(json => {
-        if(hasHttpError(json)) throw new Error(JSON.stringify(dispatch(receiveError(json))))
-        return dispatch(receiveInstitutions(json))
+        return hasHttpError(json).then(hasError => {
+          if(hasError) throw new Error(JSON.stringify(dispatch(receiveError(json))))
+          return dispatch(receiveInstitutions(json))
+        })
       })
       .then(receiveAction => {
         dispatch(fetchEachInstitution(receiveAction.institutions))

--- a/src/js/actions/fetchNewSubmission.js
+++ b/src/js/actions/fetchNewSubmission.js
@@ -9,10 +9,9 @@ export default function fetchNewSubmission(id, period) {
     dispatch(requestSubmission())
     return createSubmission(id, period)
       .then(json => {
-        return new Promise((resolve, reject) => {
-          if(hasHttpError(json)) throw new Error(JSON.stringify(dispatch(receiveError(json))))
-          dispatch(receiveSubmission(json))
-          resolve()
+        return hasHttpError(json).then(hasError => {
+          if(hasError) throw new Error(JSON.stringify(dispatch(receiveError(json))))
+          return dispatch(receiveSubmission(json))
         })
       })
       .catch(err => console.error(err))

--- a/src/js/actions/fetchPage.js
+++ b/src/js/actions/fetchPage.js
@@ -10,8 +10,10 @@ export default function fetchPage(target, pathname) {
     dispatch(getPaginationRequestAction(target))
     return fetch({pathname: pathname})
       .then(json => {
-        if(hasHttpError(json)) throw new Error(JSON.stringify(dispatch(receiveError(json))))
-        return dispatch(getPaginationReceiveAction(target, json))
+        return hasHttpError(json).then(hasError => {
+          if(hasError) throw new Error(JSON.stringify(dispatch(receiveError(json))))
+          return dispatch(getPaginationReceiveAction(target, json))
+        })
       })
       .catch(err => console.error(err))
   }

--- a/src/js/actions/fetchParseErrors.js
+++ b/src/js/actions/fetchParseErrors.js
@@ -10,8 +10,10 @@ export default function fetchParseErrors() {
     dispatch(requestParseErrors())
     return getParseErrors(getId())
       .then(json => {
-        if(hasHttpError(json)) throw new Error(JSON.stringify(dispatch(receiveError(json))))
-        return dispatch(receiveParseErrors(json))
+        return hasHttpError(json).then(hasError => {
+          if(hasError) throw new Error(JSON.stringify(dispatch(receiveError(json))))
+          return dispatch(receiveParseErrors(json))
+        })
       })
       .catch(err => console.error(err))
   }

--- a/src/js/actions/fetchProgress.js
+++ b/src/js/actions/fetchProgress.js
@@ -7,8 +7,10 @@ export default function fetchProgress(id) {
   return dispatch => {
     return getSubmission(id)
       .then(json => {
-        if(hasHttpError(json)) throw new Error(JSON.stringify(dispatch(receiveError(json))))
-        return dispatch(receiveSubmission(json))
+        return hasHttpError(json).then(hasError => {
+          if(hasError) throw new Error(JSON.stringify(dispatch(receiveError(json))))
+          return dispatch(receiveSubmission(json))
+        })
       })
       .catch(err => console.error(err))
   }

--- a/src/js/actions/fetchSignature.js
+++ b/src/js/actions/fetchSignature.js
@@ -11,14 +11,16 @@ export default function fetchSignature() {
     dispatch(requestSignature())
     return getSignature(getId())
       .then(json => {
-        if(hasHttpError(json)) throw new Error(JSON.stringify(dispatch(receiveError(json))))
-        dispatch(receiveSignature(json))
-        return dispatch(updateStatus(
-          {
-            code: json.status.code,
-            message: json.status.message
-          }
-        ))
+        return hasHttpError(json).then(hasError => {
+          if(hasError) throw new Error(JSON.stringify(dispatch(receiveError(json))))
+          dispatch(receiveSignature(json))
+          return dispatch(updateStatus(
+            {
+              code: json.status.code,
+              message: json.status.message
+            }
+          ))
+        })
       })
       .catch(err => console.error(err))
   }

--- a/src/js/actions/fetchSubmission.js
+++ b/src/js/actions/fetchSubmission.js
@@ -1,5 +1,6 @@
 import receiveSubmission from './receiveSubmission.js'
 import fetchNewSubmission from './fetchNewSubmission.js'
+import hasHttpError from './hasHttpError.js'
 import receiveError from './receiveError.js'
 import requestSubmission from './requestSubmission.js'
 import { getLatestSubmission } from '../api/api.js'
@@ -9,13 +10,16 @@ export default function fetchSubmission() {
     dispatch(requestSubmission())
     return getLatestSubmission()
       .then(json => {
-        if(!json || json.httpStatus === 500) throw new Error(JSON.stringify(dispatch(receiveError(json))))
-        if(json.httpStatus === 404){
-          const splitPath = json.path.split('/')
-          return dispatch(fetchNewSubmission(splitPath[2], splitPath[4]))
-        }else{
+        return hasHttpError(json).then(hasError => {
+          if(json.httpStatus > 399 && json.httpStatus !== 404){
+            throw new Error(JSON.stringify(dispatch(receiveError(json))))
+          }
+          if(json.httpStatus === 404){
+            const splitPath = json.path.split('/')
+            return dispatch(fetchNewSubmission(splitPath[2], splitPath[4]))
+          }
           return dispatch(receiveSubmission(json))
-        }
+        })
       })
       .catch(err => console.error(err))
   }

--- a/src/js/actions/fetchSummary.js
+++ b/src/js/actions/fetchSummary.js
@@ -10,8 +10,10 @@ export default function fetchSummary() {
     dispatch(requestSummary())
     return getSummary(getId())
       .then(json => {
-        if(hasHttpError(json)) throw new Error(JSON.stringify(dispatch(receiveError(json))))
-        return dispatch(receiveSummary(json))
+        return hasHttpError(json).then(hasError => {
+          if(hasError) throw new Error(JSON.stringify(dispatch(receiveError(json))))
+          return dispatch(receiveSummary(json))
+        })
       })
       .catch(err => console.error(err))
   }

--- a/src/js/actions/fetchVerify.js
+++ b/src/js/actions/fetchVerify.js
@@ -10,17 +10,19 @@ export default function fetchVerify(type, checked) {
   return dispatch => {
     return postVerify(getId(), type, checked)
       .then(json => {
-        if(hasHttpError(json)) throw new Error(JSON.stringify(dispatch(receiveError(json))))
+        return hasHttpError(json).then(hasError => {
+          if(hasError) throw new Error(JSON.stringify(dispatch(receiveError(json))))
 
-        if(type === 'quality') dispatch(verifyQuality(checked))
-        else dispatch(verifyMacro(checked))
+          if(type === 'quality') dispatch(verifyQuality(checked))
+          else dispatch(verifyMacro(checked))
 
-        return dispatch(updateStatus(
-          {
-            code: json.status.code,
-            message: json.status.message
-          }
-        ))
+          return dispatch(updateStatus(
+            {
+              code: json.status.code,
+              message: json.status.message
+            }
+          ))
+        })
       })
       .catch(err => console.error(err))
   }

--- a/src/js/actions/hasHttpError.js
+++ b/src/js/actions/hasHttpError.js
@@ -1,5 +1,5 @@
-export default function hasHttpError(json) {
-  return !json || json.httpStatus > 399 ?
-    true :
-    false
+export default function checkHttpError(json) {
+  if(!json) return Promise.resolve(true)
+  if(json.httpStatus === 401) return new Promise(()=>{})
+  return Promise.resolve(json.httpStatus > 399)
 }

--- a/src/js/actions/hasHttpError.js
+++ b/src/js/actions/hasHttpError.js
@@ -1,4 +1,4 @@
-export default function checkHttpError(json) {
+export default function hasHttpError(json) {
   if(!json) return Promise.resolve(true)
   if(json.httpStatus === 401) return new Promise(()=>{})
   return Promise.resolve(json.httpStatus > 399)

--- a/src/js/actions/pollForProgress.js
+++ b/src/js/actions/pollForProgress.js
@@ -11,8 +11,10 @@ export default function pollForProgress(polling) {
     if(!location.pathname.match('/upload')) return Promise.resolve()
     return getLatestSubmission()
       .then(json => {
-        if(hasHttpError(json)) throw new Error(JSON.stringify(dispatch(receiveError(json))))
-        return dispatch(receiveSubmission(json))
+        return hasHttpError(json).then(hasError => {
+          if(hasError) throw new Error(JSON.stringify(dispatch(receiveError(json))))
+          return dispatch(receiveSubmission(json))
+        })
       })
       .then(json => {
         if(json.status.code < VALIDATED_WITH_ERRORS &&

--- a/src/js/actions/updateSignature.js
+++ b/src/js/actions/updateSignature.js
@@ -11,14 +11,16 @@ export default function updateSignature(signed) {
     dispatch(requestSignaturePost())
     return postSignature(getId(), signed)
       .then(json => {
-        if(hasHttpError(json)) throw new Error(JSON.stringify(dispatch(receiveError(json))))
-        dispatch(receiveSignaturePost(json))
-        return dispatch(updateStatus(
-          {
-            code: json.status.code,
-            message: json.status.message
-          }
-        ))
+        return hasHttpError(json).then(hasError => {
+          if(hasError) throw new Error(JSON.stringify(dispatch(receiveError(json))))
+          dispatch(receiveSignaturePost(json))
+          return dispatch(updateStatus(
+            {
+              code: json.status.code,
+              message: json.status.message
+            }
+          ))
+        })
       })
       .catch(err => console.error(err))
   }

--- a/src/js/api/fetch.js
+++ b/src/js/api/fetch.js
@@ -43,10 +43,14 @@ export function fetch(options = {method: 'GET'}){
 
   return isomorphicFetch(url, fetchOptions)
     .then(response => {
+      console.log('got res', response, response.status)
       if(response.status === 401) signinRedirect()
       if(options.params && options.params.format === 'csv') {
         return response.text()
       }
       return response.json()
+    })
+    .catch(err => {
+      console.log(err)
     })
 }

--- a/src/js/components/Header.jsx
+++ b/src/js/components/Header.jsx
@@ -1,6 +1,7 @@
-import React, { PropTypes } from 'react'
+import React from 'react'
+import PropTypes from 'prop-types'
 import { Link } from 'react-router'
-import { signinRedirect, logout } from '../utils/redirect.js'
+import { logout } from '../utils/redirect.js'
 import BannerUSA from './BannerUSA.jsx'
 import BannerDeadline from '../containers/BannerDeadline.jsx'
 
@@ -53,8 +54,8 @@ const Header = (props) => {
 }
 
 Header.propTypes = {
-  user: React.PropTypes.object,
-  pathname: React.PropTypes.string
+  user: PropTypes.object,
+  pathname: PropTypes.string
 }
 
 export default Header

--- a/src/js/components/Home.jsx
+++ b/src/js/components/Home.jsx
@@ -1,6 +1,5 @@
 import React, { PropTypes } from 'react'
 import { Link } from 'react-router'
-import { signinRedirect } from '../utils/redirect.js'
 
 const renderLoggedInHero = () => {
   return (

--- a/src/js/containers/App.jsx
+++ b/src/js/containers/App.jsx
@@ -36,7 +36,7 @@ export class AppContainer extends Component {
 
   render() {
 
-    if(!this.props.oidc.user && this._userNeeded(this.props)) return null
+    if(this.props.expired || !this.props.oidc.user && this._userNeeded(this.props)) return null
 
     return (
       <div className="AppContainer">

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -31,7 +31,6 @@ fetch('/env.json').then(res => {
 
   const userManager = UserManager()
   setUserManager(userManager)
-  window.userManager = userManager
 
   const oidcMiddleware = createOidcMiddleware(userManager, () => true, false, '/oidc-callback')
   const loggerMiddleware = createLogger({collapsed: true})

--- a/src/js/reducers/user.js
+++ b/src/js/reducers/user.js
@@ -4,7 +4,7 @@ const defaultUser = {
 
 export default (state = defaultUser, action) => {
   switch (action.type) {
-    case 'redux-oidc/USER_EXPIRED':
+    case 'redux-oidc/SILENT_RENEW_ERROR':
     return {
       ...state,
       expired: true

--- a/src/js/utils/redirect.js
+++ b/src/js/utils/redirect.js
@@ -13,8 +13,12 @@ const getUserManager = () => {
 const signinRedirect = () => {
   if(!userManager) return console.error('userManager needs to be set on app initialization')
   if(process.env.NODE_ENV !== 'production') console.log('signinRedirect triggered, saving page:', location.pathname)
-  localStorage.setItem('hmdaPageBeforeSignin', location.pathname)
-  userManager.signinRedirect()
+//  localStorage.setItem('hmdaPageBeforeSignin', location.pathname)
+//  userManager.signinRedirect()
+  userManager.signinSilent()
+  userManager.signinSilentCallback().then(arg => {
+    console.log('SIGNING IN SILENTLY')
+  })
 }
 
 

--- a/src/js/utils/redirect.js
+++ b/src/js/utils/redirect.js
@@ -13,14 +13,9 @@ const getUserManager = () => {
 const signinRedirect = () => {
   if(!userManager) return console.error('userManager needs to be set on app initialization')
   if(process.env.NODE_ENV !== 'production') console.log('signinRedirect triggered, saving page:', location.pathname)
-//  localStorage.setItem('hmdaPageBeforeSignin', location.pathname)
-//  userManager.signinRedirect()
-  userManager.signinSilent()
-  userManager.signinSilentCallback().then(arg => {
-    console.log('SIGNING IN SILENTLY')
-  })
+  localStorage.setItem('hmdaPageBeforeSignin', location.pathname)
+  userManager.signinRedirect()
 }
-
 
 const restorePage = () => {
   const restored = localStorage.getItem('hmdaPageBeforeSignin')


### PR DESCRIPTION
Closes #605 

Silent sign on is now leaned on a bit more heavily and when tokens cannot be renewed silently, users are redirected to the signin page.