### PR TITLE
cleaner break between progress and parsing errors

### DIFF
--- a/src/js/components/ParseErrors.jsx
+++ b/src/js/components/ParseErrors.jsx
@@ -71,6 +71,7 @@ const ParseErrors = (props) => {
 
   return (
     <section className="ParseErrors usa-grid-full" id="parseErrors">
+      <hr />
       <header>
         {!props.pagination ? null : <h2>{total} {errorText} with Formatting Errors</h2>}
         <p className="usa-font-lead">The uploaded file is not formatted according to the requirements specified in the <a rel="noopener noreferrer" target="_blank" href="https://www.consumerfinance.gov/data-research/hmda/static/for-filers/2017/2017-HMDA-FIG.pdf">Filing Instructions Guide for data collected in 2017</a>.</p>

--- a/src/sass/components/ParseErrors.scss
+++ b/src/sass/components/ParseErrors.scss
@@ -1,4 +1,8 @@
 .ParseErrors {
+  hr {
+    margin: 2em 0 !important;
+  }
+
   h2 {
     margin-top: 0;
   }


### PR DESCRIPTION
Closes #641 

Quick update to add some spacing between progress and the errors.

## Screenshot

![parse-errors](https://user-images.githubusercontent.com/2932572/28088056-86adeac6-6652-11e7-899d-30b7af648c7e.png)
