### PR TITLE
Update redirect uri to always https version

### DIFF
--- a/env.sh
+++ b/env.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 sed \
-  -e "s@##APP_URL##@${APP_URL:-http://192.168.99.100}@"\
+  -e "s@##APP_URL##@${APP_URL:-https://192.168.99.100}@"\
   -e "s@##HMDA_API##@${HMDA_API:-https://192.168.99.100:4443/hmda}@"\
   -e "s@##KEYCLOAK_URL##@${KEYCLOAK_URL:-https://192.168.99.100:8443/auth/realms/hmda}@"\
   env.tmpl > ./dist/env.json


### PR DESCRIPTION
Companion to https://github.com/cfpb/hmda-platform/pull/1049 and https://github.com/cfpb/hmda-platform-auth/pull/126

Since the app is now always https in compose, we need to update the `redirect_uri` (as provided by the `APP_URL` envvar