### PR TITLE
Content for no submissions

### DIFF
--- a/__tests__/components/Institutions.js
+++ b/__tests__/components/Institutions.js
@@ -93,13 +93,9 @@ describe('renderStatus', () => {
   const runByCode = (code, className) => {
     it('runs with code ' + code, () => {
       const rendered = renderStatus('1234', '2017', {id: {sequenceNumber: 2}}, onDownloadClick, {code: code}, 123, 234)
-      expect(rendered.props.children[0].props.children[2].props.className).toEqual(className)
+      expect(rendered.props.children[0].props.children[1].props.className).toEqual(className)
     })
   }
-
-  it('fails on no code', () => {
-    expect(renderStatus({})).toBe(undefined)
-  })
 
   runByCode(-1, 'text-secondary')
   runByCode(1, 'text-secondary')

--- a/src/js/components/Institutions.jsx
+++ b/src/js/components/Institutions.jsx
@@ -9,7 +9,7 @@ import Alert from './Alert.jsx'
 import * as STATUS from '../constants/statusCodes.js'
 import 'uswds'
 
-export const renderDownloadLink = (institutionId, period, sequenceNumber, statusCode) => {
+export const renderDownloadLink = (institutionId, period, sequenceNumber, statusCode, onDownloadClick) => {
   if(!sequenceNumber) return null
   if(statusCode < STATUS.VALIDATED_WITH_ERRORS) return null
 
@@ -19,7 +19,7 @@ export const renderDownloadLink = (institutionId, period, sequenceNumber, status
         href="#"
         onClick={e => {
           e.preventDefault()
-          onDownloadClick(institutionId, period, submission.id.sequenceNumber)
+          onDownloadClick(institutionId, period, sequenceNumber)
         }}
       >
         Download edit report
@@ -76,7 +76,7 @@ export const renderStatus = (
     if(!submission || !submission.id) {
       downloadLink = null
     } else {
-      downloadLink = renderDownloadLink(institutionId, period, submission.id.sequenceNumber, statusCode)
+      downloadLink = renderDownloadLink(institutionId, period, submission.id.sequenceNumber, statusCode, onDownloadClick)
     }
   }
 

--- a/src/js/components/Institutions.jsx
+++ b/src/js/components/Institutions.jsx
@@ -9,6 +9,25 @@ import Alert from './Alert.jsx'
 import * as STATUS from '../constants/statusCodes.js'
 import 'uswds'
 
+export const renderDownloadLink = (institutionId, period, sequenceNumber, statusCode) => {
+  if(!sequenceNumber) return null
+  if(statusCode < STATUS.VALIDATED_WITH_ERRORS) return null
+
+  return (
+    <p className="usa-text-small">
+      <a
+        href="#"
+        onClick={e => {
+          e.preventDefault()
+          onDownloadClick(institutionId, period, submission.id.sequenceNumber)
+        }}
+      >
+        Download edit report
+      </a>
+    </p>
+  )
+}
+
 export const renderStatus = (
   institutionId,
   period,
@@ -16,53 +35,57 @@ export const renderStatus = (
   onDownloadClick,
   submissionStatus
 ) => {
-  if (!submissionStatus || !submissionStatus.code) return
-
-  const statusCode = submissionStatus.code
-  let messageClass
-
-  if (statusCode === STATUS.CREATED) {
-    messageClass = 'text-secondary'
+  let message = null
+  let description = null
+  if (!submissionStatus || !submissionStatus.message || !submissionStatus.description) {
+    message = 'not started'
+    description = 'You can begin the filing process now.'
+  } else {
+    message = submissionStatus.message
+    description = submissionStatus.description
   }
 
-  if (statusCode > STATUS.CREATED) {
+  let messageClass = 'text-primary'
+  let downloadLink
+  if(!submissionStatus || !submissionStatus.code) {
     messageClass = 'text-primary'
-  }
+  } else {
+    const statusCode = submissionStatus.code
 
-  if (
-    statusCode === STATUS.PARSED_WITH_ERRORS ||
-    statusCode === STATUS.VALIDATED_WITH_ERRORS
-  ) {
-    messageClass = 'text-secondary'
-  }
+    if (statusCode === STATUS.CREATED) {
+      messageClass = 'text-secondary'
+    }
 
-  if (statusCode === STATUS.SIGNED) {
-    messageClass = 'text-green'
-  }
+    if (
+      statusCode === STATUS.PARSED_WITH_ERRORS ||
+      statusCode === STATUS.VALIDATED_WITH_ERRORS
+    ) {
+      messageClass = 'text-secondary'
+    }
 
-  // failed submission
-  if (statusCode === STATUS.FAILED) {
-    messageClass = 'text-secondary'
+    if (statusCode === STATUS.SIGNED) {
+      messageClass = 'text-green'
+    }
+
+    // failed submission
+    if (statusCode === STATUS.FAILED) {
+      messageClass = 'text-secondary'
+    }
+
+    // only render the download link if we have a code and a submission
+    if(!submission || !submission.id) {
+      downloadLink = null
+    } else {
+      downloadLink = renderDownloadLink(institutionId, period, submission.id.sequenceNumber, statusCode)
+    }
   }
 
   return (
     <section className="status">
       <p className="status-desc">
-        Current filing status is{' '}
-        <strong className={messageClass}>{submissionStatus.message}</strong>.{' '}
-        {submissionStatus.description}
+        Current filing status is <strong className={messageClass}>{message}</strong>. {description}
       </p>
-      <p className="usa-text-small">
-        <a
-          href="#"
-          onClick={e => {
-            e.preventDefault()
-            onDownloadClick(institutionId, period, submission.id.sequenceNumber)
-          }}
-        >
-          Download edit report
-        </a>
-      </p>
+      {downloadLink}
     </section>
   )
 }


### PR DESCRIPTION
__Depends on #670__

Closes #660 

And doesn't render the "download edit report" link for the current submission unless there is one, [here](https://github.com/cfpb/hmda-platform-ui/compare/no-subs?expand=1#diff-86bed846ff53cc9ec2c51bcb085621d4R12).

Also, this doesn't help with refactoring here 😉  so I'll work on #618 next.

---

## Screenshot

![no-subs](https://user-images.githubusercontent.com/2932572/28676574-00a78c7a-72b9-11e7-9652-7b1ed4b27eb7.png)
