### PR TITLE
Filings bug on institutions page

### DIFF
--- a/__tests__/components/Institutions.js
+++ b/__tests__/components/Institutions.js
@@ -35,7 +35,7 @@ describe('Institutions', () => {
       <Institutions
         institutions={institutionsJSON.institutions}
         filingPeriod={2017}
-        filings={[filingJSON]}
+        filings={{isFetching: false, filings: [filingJSON], fetched: true}}
         submission={submission}
         user={{profile: {name: 'someone'}}}
         location={{pathname: '/institutions'}} />
@@ -76,7 +76,7 @@ describe('Institutions', () => {
         <Institutions
           institutions={institutionsJSON.institutions}
           submission={submission}
-          filings={[filingJSON]}
+          filings={{isFetching: false, filings: [filingJSON], fetched: true}}
           user={{profile: {name: 'someone'}}}
           location={{pathname: '/institutions'}} />
       </Wrapper>
@@ -91,7 +91,7 @@ describe('Institutions', () => {
           institutions={institutionsJSON.institutions}
           filingPeriod={2017}
           submission={submission}
-          filings={null}
+          filings={{isFetching: false, filings: [], fetched: true}}
           location={{pathname: '/institutions'}} />
       </Wrapper>
     )
@@ -106,7 +106,7 @@ it('renders multiple filings correctly', () => {
         institutions={institutionsJSON.institutions}
         filingPeriod={2017}
         submission={submission}
-        filings={multifilings}
+        filings={{isFetching: false, filings: multifilings, fetched: true}}
         location={{pathname: '/institutions'}} />
     </Wrapper>
   )

--- a/__tests__/reducers/filings.js
+++ b/__tests__/reducers/filings.js
@@ -6,6 +6,7 @@ import filings from '../../src/js/reducers/filings.js'
 const defaultFilings = {
   filings: [],
   isFetching: false,
+  fetched: false
 }
 
 describe('filings reducer', () => {
@@ -24,7 +25,7 @@ describe('filings reducer', () => {
   it('handles RECEIVE_FILINGS', () => {
     expect(
       filings({filings: [1,2,3]}, {type: types.RECEIVE_FILINGS})
-    ).toEqual({filings: [1,2,3], isFetching: false})
+    ).toEqual({filings: [1,2,3], isFetching: false, fetched: true})
   })
 
   it('handles CLEAR_FILINGS', () => {
@@ -33,9 +34,15 @@ describe('filings reducer', () => {
     ).toEqual(defaultFilings)
   })
 
+  it('handles REFRESH_FILINGS', () => {
+    expect(
+      filings({}, {type: types.REFRESH_STATE})
+    ).toEqual(defaultFilings)
+  })
+
   it('shouldn\'t modify state on an unknown action type', () => {
     excludeTypes(types.RECEIVE_FILING, types.RECEIVE_FILINGS,
-      types.REQUEST_FILING, types.CLEAR_FILINGS)
+      types.REQUEST_FILING, types.CLEAR_FILINGS, types.REFRESH_STATE)
       .forEach(v => expect(filings(defaultFilings, v))
         .toEqual(defaultFilings)
       )

--- a/src/js/actions/fetchSignature.js
+++ b/src/js/actions/fetchSignature.js
@@ -19,8 +19,7 @@ export default function fetchSignature() {
           dispatch(receiveSignature(json))
           return dispatch(updateStatus(
             {
-              code: json.status.code,
-              message: json.status.message
+              ...json.status
             }
           ))
         })

--- a/src/js/actions/fetchUpload.js
+++ b/src/js/actions/fetchUpload.js
@@ -21,8 +21,7 @@ export default function fetchUpload(file) {
       const uploadResponse = JSON.parse(e.target.response)
 
       dispatch(updateStatus({
-        code: uploadResponse.status.code,
-        message: uploadResponse.status.message
+        ...uploadResponse.status
       }))
 
       if(e.target.status !== 202) {

--- a/src/js/actions/fetchVerify.js
+++ b/src/js/actions/fetchVerify.js
@@ -26,8 +26,7 @@ export default function fetchVerify(type, checked) {
 
           return dispatch(updateStatus(
             {
-              code: json.status.code,
-              message: json.status.message
+              ...json.status
             }
           ))
         })

--- a/src/js/actions/updateSignature.js
+++ b/src/js/actions/updateSignature.js
@@ -19,8 +19,7 @@ export default function updateSignature(signed) {
           dispatch(receiveSignaturePost(json))
           return dispatch(updateStatus(
             {
-              code: json.status.code,
-              message: json.status.message
+              ...json.status
             }
           ))
         })

--- a/src/js/components/Institutions.jsx
+++ b/src/js/components/Institutions.jsx
@@ -197,6 +197,7 @@ export default class Institution extends Component {
   render() {
     const institutions = this.props.institutions
     const makeNewSubmission = this.props.makeNewSubmission
+
     return (
       <main id="main-content" className="usa-grid Institutions">
         {this.props.error ? <ErrorWarning error={this.props.error} /> : null}
@@ -207,11 +208,11 @@ export default class Institution extends Component {
               ? <h2>Filing Period {this.props.filingPeriod}</h2>
               : null}
           </header>
-          {this.props.isFetching || this.props.submission.isFetching
+          {this.props.filings.isFetching || this.props.submission.isFetching
             ? <div className="usa-grid-full">
                 <LoadingIcon />
               </div>
-            : !this.props.filings || this.props.filings.length === 0
+            : this.props.filings.fetched && this.props.filings.filings.length === 0
               ? <div className="usa-grid-full">
                 <Alert type="error">
                   <p>
@@ -219,7 +220,7 @@ export default class Institution extends Component {
                   </p>
                 </Alert>
                 </div>
-              : this.props.filings.map((filingObj, i) => {
+              : this.props.filings.filings.map((filingObj, i) => {
                   const filing = filingObj.filing
                   const submission = this.props.submission.id &&
                     this.props.submission.id.institutionId === filing.institutionId
@@ -305,7 +306,7 @@ export default class Institution extends Component {
 
 Institution.propTypes = {
   params: PropTypes.object,
-  filings: PropTypes.array,
+  filings: PropTypes.object,
   institutions: PropTypes.array,
   makeNewSubmission: PropTypes.func,
   onDownloadClick: PropTypes.func

--- a/src/js/containers/Institutions.jsx
+++ b/src/js/containers/Institutions.jsx
@@ -13,7 +13,7 @@ export class InstitutionContainer extends Component {
   }
 
   componentDidMount() {
-    if(!this.props.institutions) this.props.dispatch(fetchInstitutions())
+    if(!this.props.institutions || !this.props.filings.fetched) this.props.dispatch(fetchInstitutions())
   }
 
   render() {
@@ -26,17 +26,12 @@ export function mapStateToProps(state) {
 
   const {
     filings,
-    isFetching
-  } = state.app.filings
-
-  const {
     submission,
     error,
     filingPeriod
   } = state.app
 
   return {
-    isFetching,
     submission,
     filingPeriod,
     institutions,

--- a/src/js/reducers/filings.js
+++ b/src/js/reducers/filings.js
@@ -1,8 +1,9 @@
-import { REQUEST_FILING,RECEIVE_FILING,CLEAR_FILINGS,RECEIVE_FILINGS } from '../constants'
+import { REQUEST_FILING,RECEIVE_FILING,CLEAR_FILINGS,RECEIVE_FILINGS, REFRESH_STATE } from '../constants'
 
 const defaultFilings = {
   filings: [],
   isFetching: false,
+  fetched: false
 }
 
 /*
@@ -15,7 +16,8 @@ export default (state = defaultFilings, action) => {
   case REQUEST_FILING:
     return {
       ...state,
-      isFetching: true
+      isFetching: true,
+      fetched: false
     }
   case RECEIVE_FILING:
     return {
@@ -27,8 +29,11 @@ export default (state = defaultFilings, action) => {
   case RECEIVE_FILINGS:
       return {
         ...state,
-        isFetching: false
+        isFetching: false,
+        fetched: true
       }
+  case REFRESH_STATE:
+      return defaultFilings
   default:
     return state
   }


### PR DESCRIPTION
Closes #733 
Closes #732 
 - Fixes `updateStatus` to use every status key, which allows the proper message to be rendered on the institutions page without refiling.
 - Respects `REFRESH_STATE` on filings, closing the above bugs.
 - Adds `fetched` key to filings state so the lack of filings error warning isn't aggressively rendered on default data