### PR TITLE
Better loading icons

### DIFF
--- a/__tests__/components/EditsTableWrapper.js
+++ b/__tests__/components/EditsTableWrapper.js
@@ -25,6 +25,8 @@ describe('EditsTableWrapper', () => {
       onDownloadClick: onDownloadClick,
       page: 'quality',
       pagination: {},
+      isFetching: false,
+      fetched: true,
       rows: {
         S020: {
           isFetching: false,
@@ -43,6 +45,33 @@ describe('EditsTableWrapper', () => {
   })
 })
 
+describe('EditsTableWrapper Loading', () => {
+  const onDownloadClick = jest.fn()
+
+  it('renders loading icon is necessary', () => {
+    const rendered = EditsTableWrapper({
+      onDownloadClick: onDownloadClick,
+      page: 'quality',
+      pagination: {},
+      isFetching: true,
+      fetched: false,
+      rows: {
+        S020: {
+          isFetching: true,
+          rows: []
+        }
+      },
+      types: {
+        syntactical: types.syntactical,
+        validity: types.validity,
+        quality: types.quality,
+        macro: types.macro
+      }
+    })
+
+    expect(typeof rendered.type).toBe('function')
+  })
+})
 describe('renderTablesOrSuccess', () => {
   it('render the success message with verification note if NO edits and q/m', () => {
     const rendered = renderTablesOrSuccess({}, [], 'quality')

--- a/src/js/components/EditsTableWrapper.jsx
+++ b/src/js/components/EditsTableWrapper.jsx
@@ -57,18 +57,20 @@ const EditsTableWrapper = props => {
     return null
   }
 
-  const loading = props.isFetching ? <LoadingIcon /> : null
+  const loading = !props.fetched || props.isFetching ? <LoadingIcon /> : null
 
   return (
-    <section className="EditsTableWrapper">
-      {loading}
-      {type === 'syntacticalvalidity'
-        ? makeEntry(props, 'syntactical')
-        : makeEntry(props, type)}
-      {type === 'syntacticalvalidity' ? makeEntry(props, 'validity') : null}
-      {type === 'quality' || type === 'macro' ? <Verifier type={type} /> : null}
-      <hr />
-    </section>
+    loading
+    ? loading
+    : <section className="EditsTableWrapper">
+        {loading}
+        {type === 'syntacticalvalidity'
+          ? makeEntry(props, 'syntactical')
+          : makeEntry(props, type)}
+        {type === 'syntacticalvalidity' ? makeEntry(props, 'validity') : null}
+        {type === 'quality' || type === 'macro' ? <Verifier type={type} /> : null}
+        <hr />
+      </section>
   )
 }
 

--- a/src/js/components/Institutions.jsx
+++ b/src/js/components/Institutions.jsx
@@ -208,7 +208,7 @@ export default class Institution extends Component {
               ? <h2>Filing Period {this.props.filingPeriod}</h2>
               : null}
           </header>
-          {this.props.filings.isFetching || this.props.submission.isFetching
+          {!this.props.filings.fetched || this.props.filings.isFetching || this.props.submission.isFetching
             ? <div className="usa-grid-full">
                 <LoadingIcon />
               </div>


### PR DESCRIPTION
Uses presence of `fetched` key in state to show a loading icon if data has not been fetched, not just when fetching begins. This prevents an initial render of default data.