### PR TITLE
Instead of building an env file, just sed the bundle directly

### DIFF
--- a/env.sh
+++ b/env.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
-sed \
+sed -i.bak \
   -e "s@##APP_URL##@${APP_URL:-https://192.168.99.100}@"\
   -e "s@##HMDA_API##@${HMDA_API:-https://192.168.99.100:4443/hmda}@"\
   -e "s@##KEYCLOAK_URL##@${KEYCLOAK_URL:-https://192.168.99.100:8443/auth/realms/hmda}@"\
-  env.tmpl > ./dist/env.json
+  ./dist/js/app.min.js && rm ./dist/js/app.min.js.bak
 
 if [ -f /etc/nginx/nginx.tmpl ]; then
   sed \

--- a/env.sh
+++ b/env.sh
@@ -1,9 +1,18 @@
 #!/bin/bash
-sed -i.bak \
-  -e "s@##APP_URL##@${APP_URL:-https://192.168.99.100}@"\
-  -e "s@##HMDA_API##@${HMDA_API:-https://192.168.99.100:4443/hmda}@"\
-  -e "s@##KEYCLOAK_URL##@${KEYCLOAK_URL:-https://192.168.99.100:8443/auth/realms/hmda}@"\
-  ./dist/js/app.min.js && rm ./dist/js/app.min.js.bak
+
+if [ -f ./dist/js/app.min.js.bak ]; then
+  sed \
+    -e "s@##APP_URL##@${APP_URL:-https://192.168.99.100}@"\
+    -e "s@##HMDA_API##@${HMDA_API:-https://192.168.99.100:4443/hmda}@"\
+    -e "s@##KEYCLOAK_URL##@${KEYCLOAK_URL:-https://192.168.99.100:8443/auth/realms/hmda}@"\
+    ./dist/js/app.min.js.bak > ./dist/js/app.min.js
+else
+  sed -i.bak \
+    -e "s@##APP_URL##@${APP_URL:-https://192.168.99.100}@"\
+    -e "s@##HMDA_API##@${HMDA_API:-https://192.168.99.100:4443/hmda}@"\
+    -e "s@##KEYCLOAK_URL##@${KEYCLOAK_URL:-https://192.168.99.100:8443/auth/realms/hmda}@"\
+    ./dist/js/app.min.js
+fi
 
 if [ -f /etc/nginx/nginx.tmpl ]; then
   sed \

--- a/env.tmpl
+++ b/env.tmpl
@@ -1,5 +1,0 @@
-{
-  "APP_URL": "##APP_URL##",
-  "HMDA_API": "##HMDA_API##",
-  "KEYCLOAK_URL": "##KEYCLOAK_URL##"
-}

--- a/src/index.html
+++ b/src/index.html
@@ -7,7 +7,6 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="shortcut icon" href="/img/favicons/favicon.ico" type="image/x-icon">
   <link rel="stylesheet" href="/css/app.min.css">
-  <link rel="prefetch" href="/env.json">
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
   new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],

--- a/src/js/api/fetch.js
+++ b/src/js/api/fetch.js
@@ -43,13 +43,15 @@ export function fetch(options = {method: 'GET'}){
 
   return isomorphicFetch(url, fetchOptions)
     .then(response => {
-      if(process.env.NODE_ENV !== 'production') console.log('got res', response, response.status)
-      if(response.status === 401) signinRedirect()
-      if(response.status > 399) return response
-      if(options.params && options.params.format === 'csv') {
-        return response.text()
-      }
-      return response.json()
+      return new Promise(resolve => {
+        if(process.env.NODE_ENV !== 'production') console.log('got res', response, response.status)
+        if(response.status === 401) signinRedirect()
+        if(response.status > 399) resolve(response)
+        if(options.params && options.params.format === 'csv') {
+          resolve(response.text())
+        }
+        setTimeout(()=>resolve(response.json()), 0)
+      })
     })
     .catch(err => {
       console.log(err)


### PR DESCRIPTION
Requiring an `env.json` file increases initial load time significantly, as the browser needs to wait for a roundtrip before executing the rest of the JS, specifically the initial render.

This modifies the `env.sh` script to build the bundle directly, either in place (generating a `.bak`) or from an existing `.bak`. This allows the dev build to work while also allowing runtime replacement of the envvars in the container.