### PR TITLE
Bump version of node if building dockerfile in dev

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ARG SKIP_JS_BUILD
 
 RUN if [ -z ${SKIP_JS_BUILD+x} ]; then echo "Installing JS deps" && apt-get update && \
     apt-get install -y curl && \
-    curl -sL https://deb.nodesource.com/setup_7.x | bash - && \
+    curl -sL https://deb.nodesource.com/setup_8.x | bash - && \
     apt-get install -y nodejs && \
     curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
     echo "deb https://dl.yarnpkg.com/debian/ v0.27.5 main" | tee /etc/apt/sources.list.d/yarn.list && \


### PR DESCRIPTION
This is rarely used, but should be consistent