### PR TITLE
add logo to header

### DIFF
--- a/src/js/components/Footer.jsx
+++ b/src/js/components/Footer.jsx
@@ -1,0 +1,74 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { Link } from 'react-router'
+
+const Footer = () => {
+  return (
+    <footer className="Footer usa-footer usa-footer-slim" role="contentinfo">
+      <div className="usa-grid usa-footer-return-to-top">
+        <a href="#">Return to top</a>
+      </div>
+      <div className="usa-footer-primary-section">
+        <div className="usa-grid-full">
+          <nav className="usa-footer-nav usa-width-one-third">
+            <ul className="usa-unstyled-list">
+              <li className="usa-footer-primary-content">
+                <Link
+                  className="usa-nav-link"
+                  to={'/'}
+                  title="Home"
+                  aria-label="Home"
+                >
+                  <img src="/img/ffiec-logo.png" width="75px" alt="FFIEC" />
+                  HMDA Platform
+                </Link>
+              </li>
+            </ul>
+          </nav>
+          <div className="usa-width-one-third">
+            <h4>Resources</h4>
+
+            <ul className="usa-unstyled-list">
+              <li>
+                <a href="https://www.ffiec.gov/hmda/">FFIEC HMDA Website</a>
+              </li>
+              <li>
+                <a href="https://www.federalregister.gov/documents/2015/10/28/2015-26607/home-mortgage-disclosure-regulation-c">
+                  HMDA Final Rule
+                </a>
+              </li>
+              <li>
+                <a href="https://www.consumerfinance.gov/policy-compliance/guidance/implementation-guidance/hmda-implementation/">
+                  Regulatory Implementation Resources
+                </a>
+              </li>
+              <li>
+                <a href="https://www.consumerfinance.gov/data-research/hmda/for-filers">
+                  Resources for HMDA Filers
+                </a>
+              </li>
+              <li>
+                <a href="mailto:hmdahelp@cfpb.gov">Contact Us</a>
+              </li>
+            </ul>
+          </div>
+          <div className="usa-width-one-third">
+            <h4>HMDA Platform Tools</h4>
+
+            <ul className="usa-unstyled-list">
+              <li>
+                <a href="https://cfpb.github.io/hmda-platform-tools/file-format-verification/">
+                  File Format Verification Tool
+                </a>
+              </li>
+              {/*<li>Check Digit Generator</li>
+              <li>Rate Spread Calculator</li>*/}
+            </ul>
+          </div>
+        </div>
+      </div>
+    </footer>
+  )
+}
+
+export default Footer

--- a/src/js/components/Header.jsx
+++ b/src/js/components/Header.jsx
@@ -8,7 +8,7 @@ import BannerUSA from './BannerUSA.jsx'
 import BannerDeadline from '../containers/BannerDeadline.jsx'
 
 export const addActiveClass = (selected, current) => {
-  if(selected === current) return 'active'
+  if (selected === current) return 'active'
   return null
 }
 
@@ -16,37 +16,52 @@ const makeNav = (props, page) => {
   let userHeader = (
     <ul className="usa-nav-primary">
       {props.user ? <li>{props.user.profile.name}</li> : null}
-      {props.user ? <li><a className="usa-nav-link" href="#" onClick={(e) => {
-         e.preventDefault()
-         logout()
-      }}>Logout</a></li> : null}
-      <li><HomeLink/></li>
+      {props.user ? (
+        <li>
+          <a
+            className="usa-nav-link"
+            href="#"
+            onClick={e => {
+              e.preventDefault()
+              logout()
+            }}
+          >
+            Logout
+          </a>
+        </li>
+      ) : null}
+      <li>
+        <HomeLink />
+      </li>
     </ul>
   )
 
-  if(page === 'oidc-callback') userHeader = null
+  if (page === 'oidc-callback') userHeader = null
 
-  return <nav role="navigation" className="usa-nav">
-    {userHeader}
-  </nav>
+  return (
+    <nav role="navigation" className="usa-nav">
+      {userHeader}
+    </nav>
+  )
 }
 
-const Header = (props) => {
+const Header = props => {
   const page = props.pathname.split('/').slice(-1)[0]
 
   return (
-    <header className="Header usa-header usa-header-basic" id="header" role="banner">
+    <header
+      className="Header usa-header usa-header-basic"
+      id="header"
+      role="banner"
+    >
       <BannerBeta />
       <BannerUSA />
       <BannerDeadline />
       <section className="usa-nav-container">
         <div className="usa-logo" id="logo">
           <em className="usa-logo-text">
-            <Link
-              className="usa-nav-link"
-              to={'/'}
-              title="Home"
-              aria-label="Home">HMDA Platform</Link>
+            <img src="/img/ffiec-logo.png" width="100px" alt="FFIEC" />
+            HMDA Platform
           </em>
         </div>
         {makeNav(props, page)}

--- a/src/js/components/Header.jsx
+++ b/src/js/components/Header.jsx
@@ -60,8 +60,15 @@ const Header = props => {
       <section className="usa-nav-container">
         <div className="usa-logo" id="logo">
           <em className="usa-logo-text">
-            <img src="/img/ffiec-logo.png" width="100px" alt="FFIEC" />
-            HMDA Platform
+            <Link
+              className="usa-nav-link"
+              to={'/'}
+              title="Home"
+              aria-label="Home"
+            >
+              <img src="/img/ffiec-logo.png" width="100px" alt="FFIEC" />
+              HMDA Platform
+            </Link>
           </em>
         </div>
         {makeNav(props, page)}

--- a/src/js/containers/App.jsx
+++ b/src/js/containers/App.jsx
@@ -5,6 +5,7 @@ import ConfirmationModal from './ConfirmationModal.jsx'
 import LoggedOutModal from '../components/LoggedOutModal.jsx'
 import * as AccessToken from '../api/AccessToken.js'
 import Header from '../components/Header.jsx'
+import Footer from '../components/Footer.jsx'
 import BrowserBlocker from '../components/BrowserBlocker.jsx'
 import browser from 'detect-browser'
 
@@ -61,42 +62,7 @@ export class AppContainer extends Component {
               <BrowserBlocker/> :
               this.props.children
         }
-        <footer className="usa-footer usa-footer-slim" role="contentinfo">
-          <div className="usa-grid usa-footer-return-to-top">
-            <a href="#">Return to top</a>
-          </div>
-          <div className="usa-footer-primary-section">
-            <div className="usa-grid-full">
-              <nav className="usa-footer-nav usa-width-one-third">
-                <ul className="usa-unstyled-list">
-                  <li className="usa-footer-primary-content">
-                    <a title="FFIEC website" href="https://www.ffiec.gov/"><img src="/img/ffiec-logo.png" width="100px" alt="FFIEC"/></a>
-                  </li>
-                </ul>
-              </nav>
-              <div className="usa-width-one-third">
-                <h4>Resources</h4>
-
-                <ul className="usa-unstyled-list">
-                  <li><a href="https://www.ffiec.gov/hmda/">FFIEC HMDA Website</a></li>
-                  <li><a href="https://www.federalregister.gov/documents/2015/10/28/2015-26607/home-mortgage-disclosure-regulation-c">HMDA Final Rule</a></li>
-                  <li><a href="https://www.consumerfinance.gov/policy-compliance/guidance/implementation-guidance/hmda-implementation/">Regulatory Implementation Resources</a></li>
-                  <li><a href="https://www.consumerfinance.gov/data-research/hmda/for-filers">Resources for HMDA Filers</a></li>
-                  <li><a href="mailto:hmdahelp@cfpb.gov">Contact Us</a></li>
-                </ul>
-              </div>
-              <div className="usa-width-one-third">
-                <h4>HMDA Platform Tools</h4>
-
-                <ul className="usa-unstyled-list">
-                  <li><a href="https://cfpb.github.io/hmda-platform-tools/file-format-verification/">File Format Verification Tool</a></li>
-                  {/*<li>Check Digit Generator</li>
-                  <li>Rate Spread Calculator</li>*/}
-                </ul>
-              </div>
-            </div>
-          </div>
-        </footer>
+        <Footer />
       </div>
     )
   }

--- a/src/sass/app.scss
+++ b/src/sass/app.scss
@@ -15,6 +15,7 @@
 // Components
 @import "components/Home.scss";
 @import "components/Header.scss";
+@import "components/Footer.scss";
 @import "components/ErrorWarning.scss";
 @import "components/Pagination.scss";
 @import "components/LoadingIcon.scss";

--- a/src/sass/components/Footer.scss
+++ b/src/sass/components/Footer.scss
@@ -1,0 +1,12 @@
+.Footer {
+  .usa-nav-link {
+    color: $color-base;
+    font-size: 0.9em;
+    text-decoration: none;
+
+    img {
+      margin-right: 5px;
+      vertical-align: top;
+    }
+  }
+}

--- a/src/sass/components/Header.scss
+++ b/src/sass/components/Header.scss
@@ -4,9 +4,14 @@
     padding: 0;
   }
   .usa-logo {
-    img {
-      margin-right: .5em;
-      vertical-align: text-bottom;
+    .usa-logo-text {
+      font-size: 2.15rem;
+      font-weight: normal;
+
+      img {
+        margin-right: .5em;
+        vertical-align: text-bottom;
+      }
     }
   }
 }

--- a/src/sass/components/Header.scss
+++ b/src/sass/components/Header.scss
@@ -3,10 +3,10 @@
     margin: 0;
     padding: 0;
   }
-  .usa-nav-primary {
-    .usa-button {
-      width: 5.5em;
-      padding: 1rem 0;
+  .usa-logo {
+    img {
+      margin-right: .5em;
+      vertical-align: text-bottom;
     }
   }
 }

--- a/src/sass/components/Header.scss
+++ b/src/sass/components/Header.scss
@@ -4,6 +4,9 @@
     padding: 0;
   }
   .usa-logo {
+    a:hover {
+      color: $color-base;
+    }
     .usa-logo-text {
       font-size: 2.15rem;
       font-weight: normal;


### PR DESCRIPTION
Closes #754 

This adds the logo to the header but also removes the link from the "HDMA Platform" text. This link took the filers to the home page. We did add a "HOME" link to the navigation a while back to take care of this.

Also in that thought was that the footer still has the FFIEC logo and it links to the [FFIEC home page](https://www.ffiec.gov/). It felt weird that the header logo/platform text would go to the app home page but the footer logo would go somewhere else. _Screenshots are below to show where we are using the logo._

Should we also remove the link from the FFIEC logo in the footer as well (we have another link in the footer that goes there)? Other thoughts?

_Also some formatting changes, [here are the important lines](https://github.com/cfpb/hmda-platform-ui/pull/766/files?w=1#diff-92687e6d8308aa62dd8f6bfd53b414d3R63)._

### Header
![header](https://user-images.githubusercontent.com/2932572/30333859-f6b797e2-97ab-11e7-815a-d0d0071d29cd.png)

### Footer
![footer](https://user-images.githubusercontent.com/2932572/30333867-fa9c1d74-97ab-11e7-999d-da10fd6d8324.png)
