### PR TITLE
Set envvars for non-default docker-machine host

### DIFF
--- a/env.sh
+++ b/env.sh
@@ -1,5 +1,14 @@
 #!/bin/bash
 
+get_baseurl () {
+  local proto=$(echo ${1} | sed -e's,^\(.*://\).*,\1,g')
+  local baseUrl=$(echo ${1} | awk -F/ '{print $3}')
+  echo "${proto}${baseUrl}"
+}
+
+KEYCLOAK_SERVER=$(get_baseurl ${KEYCLOAK_URL})
+HMDA_API_SERVER=$(get_baseurl ${HMDA_API})
+
 if [ -f ./dist/js/app.min.js.bak ]; then
   sed \
     -e "s@##APP_URL##@${APP_URL:-https://192.168.99.100}@"\
@@ -16,7 +25,7 @@ fi
 
 if [ -f /etc/nginx/nginx.tmpl ]; then
   sed \
-  -e "s@##APP_SERVER##@${APP_SERVER:-https://192.168.99.100}@g"\
+  -e "s@##APP_SERVER##@${APP_URL:-https://192.168.99.100}@g"\
   -e "s@##KEYCLOAK_SERVER##@${KEYCLOAK_SERVER:-https://192.168.99.100:8443}@g"\
   -e "s@##HMDA_API_SERVER##@${HMDA_API_SERVER:-https://192.168.99.100:4443}@g"\
   /etc/nginx/nginx.tmpl > /etc/nginx/nginx.conf


### PR DESCRIPTION
I noticed that the docker-compose file in hmda-platform does not provide the `_SERVER` env vars leading to this not working for non-default docker-machine hosts. I am running the platform with "Docker for mac/Moby".

Extracting the base url from `_URL` vars seems to make sense for HMDA_API_URL and KEYCLOAK_URL. Let me know if I can improve the PR further.