### PR TITLE
Polling backoff

### DIFF
--- a/__tests__/actions/pollForProgress.js
+++ b/__tests__/actions/pollForProgress.js
@@ -69,6 +69,6 @@ describe('pollForProgress', () => {
     expect(dg()).toBe(1000)
     expect(dg()).toBe(1200)
     for(let i=-1; i<30; i++) {dg()}
-    expect(dg()).toBe(30000)
+    expect(dg()).toBe(20000)
   })
 })

--- a/__tests__/actions/pollForProgress.js
+++ b/__tests__/actions/pollForProgress.js
@@ -2,7 +2,7 @@ jest.mock('../../src/js/api/api')
 jest.unmock('../../src/js/actions/pollForProgress.js')
 jest.unmock('../../src/js/constants')
 import * as types from '../../src/js/constants'
-import pollForProgress from '../../src/js/actions/pollForProgress.js'
+import pollForProgress, { makeDurationGetter } from '../../src/js/actions/pollForProgress.js'
 import configureMockStore from 'redux-mock-store'
 import thunk from 'redux-thunk'
 import { getLatestSubmission, getEdits } from '../../src/js/api/api.js'
@@ -61,5 +61,14 @@ describe('pollForProgress', () => {
         console.log(err)
         done.fail()
       })
+  })
+
+  it('makes a duration getter properly', () => {
+    const dg = makeDurationGetter()
+    expect(dg).toBeDefined()
+    expect(dg()).toBe(1000)
+    expect(dg()).toBe(1200)
+    for(let i=-1; i<30; i++) {dg()}
+    expect(dg()).toBe(30000)
   })
 })

--- a/src/js/actions/pollForProgress.js
+++ b/src/js/actions/pollForProgress.js
@@ -5,7 +5,19 @@ import hasHttpError from './hasHttpError.js'
 import { getLatestSubmission } from '../api/api.js'
 import { PARSED_WITH_ERRORS, VALIDATED_WITH_ERRORS } from '../constants/statusCodes.js'
 
+export const makeDurationGetter = () => {
+  let count = 0
+  return () => {
+    let duration = Math.pow(1.2, count)*1000>>0
+    if (duration > 30000) duration = 30000
+    else count++
+    return duration
+  }
+}
+
 export default function pollForProgress(polling) {
+  const getTimeoutDuration = makeDurationGetter()
+
   const poller = dispatch => {
     if(!polling) return Promise.resolve()
     if(!location.pathname.match('/upload')) return Promise.resolve()
@@ -22,7 +34,7 @@ export default function pollForProgress(polling) {
       .then(json => {
         if(json.status.code < VALIDATED_WITH_ERRORS &&
            json.status.code !== PARSED_WITH_ERRORS){
-             setTimeout(() => poller(dispatch), 1000)
+             setTimeout(() => poller(dispatch), getTimeoutDuration())
         } else {
           return dispatch(fetchEdits())
         }

--- a/src/js/actions/pollForProgress.js
+++ b/src/js/actions/pollForProgress.js
@@ -9,7 +9,7 @@ export const makeDurationGetter = () => {
   let count = 0
   return () => {
     let duration = Math.pow(1.2, count)*1000>>0
-    if (duration > 30000) duration = 30000
+    if (duration > 20000) duration = 20000
     else count++
     return duration
   }


### PR DESCRIPTION
Closes #770 

During upload, the `pollForProgress` action now slowly backs off, up to a maximum of a request every 20s. This will greatly reduce network traffic to the backend with a fairly small delay relative to total upload time.