### PR TITLE
Upload messages

### DIFF
--- a/__tests__/components/UploadForm.js
+++ b/__tests__/components/UploadForm.js
@@ -3,7 +3,8 @@ jest.unmock('../../src/js/components/ValidationProgress.jsx')
 
 import UploadForm, {
   renderValidationProgress,
-  renderErrors
+  renderErrors,
+  getDropzoneText
 } from '../../src/js/components/UploadForm.jsx'
 import ValidationProgress from '../../src/js/components/ValidationProgress.jsx'
 import Wrapper from '../Wrapper.js'
@@ -11,7 +12,7 @@ import React from 'react'
 import ReactDOM from 'react-dom'
 import TestUtils from 'react-addons-test-utils'
 
-describe('submitform', function(){
+describe('submitform', function() {
   const setFile = jest.fn()
   const pollSubmission = jest.fn()
   const poll2 = jest.fn()
@@ -19,20 +20,22 @@ describe('submitform', function(){
   // use ReactDOM.render instead to be able to test componentDidUpdate
   const node = document.createElement('div')
   const form = ReactDOM.render(
-      <Wrapper>
-        <UploadForm
-          pollSubmission={pollSubmission}
-          setFile={setFile}
-          uploading={true}
-          file={{size:108}}
-          code={5}
-          filingPeriod='2017'
-          errors={['this is an error', 'and another']}
-        />
-      </Wrapper>, node)
+    <Wrapper>
+      <UploadForm
+        pollSubmission={pollSubmission}
+        setFile={setFile}
+        uploading={true}
+        file={{ size: 108 }}
+        code={5}
+        filingPeriod="2017"
+        errors={['this is an error', 'and another']}
+      />
+    </Wrapper>,
+    node
+  )
   const formNode = ReactDOM.findDOMNode(form)
 
-  it('renders the form', function(){
+  it('renders the form', function() {
     expect(formNode).toBeDefined()
   })
 
@@ -46,16 +49,18 @@ describe('submitform', function(){
   })
 
   const form2 = ReactDOM.render(
-      <Wrapper>
-        <UploadForm
-          pollSubmission={poll2}
-          code={1}
-          setFile={setFile}
-          uploading={true}
-          file={{size:200}}
-          errors={[]}
-        />
-      </Wrapper>, node)
+    <Wrapper>
+      <UploadForm
+        pollSubmission={poll2}
+        code={1}
+        setFile={setFile}
+        uploading={true}
+        file={{ size: 200 }}
+        errors={[]}
+      />
+    </Wrapper>,
+    node
+  )
   const form2Node = ReactDOM.findDOMNode(form2)
 
   it('expects the file input to be empty', () => {
@@ -69,26 +74,139 @@ describe('submitform', function(){
 })
 
 describe('renderErrors', () => {
-  const getClass = component =>
-    component.props.className
+  const getClass = component => component.props.className
 
   it('renders errors', () => {
     const rendered = renderErrors(['this is an error'])
     expect(!!getClass(rendered).match('usa-alert usa-alert-error')).toBe(true)
   })
 
-  it('doesn\'t renders errors', () => {
+  it("doesn't renders errors", () => {
     expect(renderErrors([])).toBe(null)
+  })
+})
+
+describe('getDropZoneText', () => {
+  const props = {
+    code: 0,
+    errors: [],
+    filename: ''
+  }
+
+  it('renders initially', () => {
+    const rendered = getDropzoneText({
+      code: 0,
+      errors: [],
+      filename: ''
+    })
+    //console.log(rendered.props.children.props.children)
+    expect(rendered.props.children.props.children).toBe(
+      'To begin uploading a file, drag it into this box or click here.'
+    )
+  })
+
+  it('renders while uploading', () => {
+    const rendered = getDropzoneText({
+      code: 1,
+      errors: [],
+      filename: ''
+    })
+    expect(rendered.props.children.props.children).toBe(
+      'To begin uploading a new file, drag it into this box or click here.'
+    )
+  })
+
+  it('renders after uploaded', () => {
+    const rendered = getDropzoneText({
+      code: 2,
+      errors: [],
+      filename: 'filename.txt'
+    })
+    expect(rendered.props.children.props.children.length).toBe(2)
+    expect(rendered.props.children.props.children[0].props.children[2]).toBe(
+      ' is currently in progress.'
+    )
+  })
+
+  it('renders with formatting errors', () => {
+    const rendered = getDropzoneText({
+      code: 5,
+      errors: [],
+      filename: 'filename.txt'
+    })
+    expect(rendered.props.children.props.children.length).toBe(2)
+    expect(rendered.props.children.props.children[0].props.children[2]).toBe(
+      ' has formatting errors.'
+    )
+  })
+
+  it('renders with validation errors', () => {
+    const rendered = getDropzoneText({
+      code: 8,
+      errors: [],
+      filename: 'filename.txt'
+    })
+    expect(rendered.props.children.props.children.length).toBe(2)
+    expect(rendered.props.children.props.children[0].props.children[2]).toBe(
+      ' is ready for review.'
+    )
+  })
+
+  it('renders validated', () => {
+    const rendered = getDropzoneText({
+      code: 9,
+      errors: [],
+      filename: 'filename.txt'
+    })
+    expect(rendered.props.children.props.children.length).toBe(2)
+    expect(rendered.props.children.props.children[0].props.children[2]).toBe(
+      ' is ready for submission.'
+    )
+  })
+
+  it('renders signed', () => {
+    const rendered = getDropzoneText({
+      code: 10,
+      errors: [],
+      filename: 'filename.txt'
+    })
+    expect(rendered.props.children.props.children.length).toBe(2)
+    expect(rendered.props.children.props.children[0].props.children[2]).toBe(
+      ' is complete.'
+    )
+  })
+
+  it('renders signed WITHOUT a filename', () => {
+    const rendered = getDropzoneText({
+      code: 10,
+      errors: [],
+      filename: ''
+    })
+    expect(rendered.props.children).toBe(
+      'To begin uploading a new file, drag it into this box or click here.'
+    )
+  })
+
+  it('renders errors', () => {
+    const rendered = getDropzoneText({
+      code: 10,
+      errors: ['an error'],
+      filename: 'filename.txt'
+    })
+    expect(rendered.props.children.props.children.length).toBe(2)
+    expect(rendered.props.children.props.children[0].props.children[1]).toBe(
+      ' can not be uploaded.'
+    )
   })
 })
 
 describe('renderValidationProgress', () => {
   it('renders validation progress', () => {
-    const rendered = renderValidationProgress({code: 2})
+    const rendered = renderValidationProgress({ code: 2 })
     expect(TestUtils.isElement(rendered)).toBe(true)
   })
 
-  it('doesn\'t renders validation progress', () => {
-    expect(renderValidationProgress({code: 1})).toBe(null)
+  it("doesn't renders validation progress", () => {
+    expect(renderValidationProgress({ code: 1 })).toBe(null)
   })
 })

--- a/__tests__/components/UploadForm.js
+++ b/__tests__/components/UploadForm.js
@@ -123,8 +123,8 @@ describe('getDropZoneText', () => {
       filename: 'filename.txt'
     })
     expect(rendered.props.children.props.children.length).toBe(2)
-    expect(rendered.props.children.props.children[0].props.children[2]).toBe(
-      ' is currently in progress.'
+    expect(rendered.props.children.props.children[0].props.children[4]).toBe(
+      'is currently in progress.'
     )
   })
 
@@ -135,8 +135,8 @@ describe('getDropZoneText', () => {
       filename: 'filename.txt'
     })
     expect(rendered.props.children.props.children.length).toBe(2)
-    expect(rendered.props.children.props.children[0].props.children[2]).toBe(
-      ' has formatting errors.'
+    expect(rendered.props.children.props.children[0].props.children[4]).toBe(
+      'has formatting errors.'
     )
   })
 
@@ -147,8 +147,8 @@ describe('getDropZoneText', () => {
       filename: 'filename.txt'
     })
     expect(rendered.props.children.props.children.length).toBe(2)
-    expect(rendered.props.children.props.children[0].props.children[2]).toBe(
-      ' is ready for review.'
+    expect(rendered.props.children.props.children[0].props.children[4]).toBe(
+      'is ready for review.'
     )
   })
 
@@ -159,8 +159,8 @@ describe('getDropZoneText', () => {
       filename: 'filename.txt'
     })
     expect(rendered.props.children.props.children.length).toBe(2)
-    expect(rendered.props.children.props.children[0].props.children[2]).toBe(
-      ' is ready for submission.'
+    expect(rendered.props.children.props.children[0].props.children[4]).toBe(
+      'is ready for submission.'
     )
   })
 
@@ -171,8 +171,8 @@ describe('getDropZoneText', () => {
       filename: 'filename.txt'
     })
     expect(rendered.props.children.props.children.length).toBe(2)
-    expect(rendered.props.children.props.children[0].props.children[2]).toBe(
-      ' is complete.'
+    expect(rendered.props.children.props.children[0].props.children[4]).toBe(
+      'is complete.'
     )
   })
 
@@ -194,8 +194,8 @@ describe('getDropZoneText', () => {
       filename: 'filename.txt'
     })
     expect(rendered.props.children.props.children.length).toBe(2)
-    expect(rendered.props.children.props.children[0].props.children[1]).toBe(
-      ' can not be uploaded.'
+    expect(rendered.props.children.props.children[0].props.children[4]).toBe(
+      'can not be uploaded.'
     )
   })
 })

--- a/src/js/components/UploadForm.jsx
+++ b/src/js/components/UploadForm.jsx
@@ -25,6 +25,17 @@ export const renderErrors = errors => {
   )
 }
 
+const _getUploadMessage = (preText, filename, postText, howToMessage) => {
+  return (
+    <div>
+      <p>
+        {preText} <strong>{filename}</strong> {postText}
+      </p>
+      <p className="file-selected">{howToMessage}</p>
+    </div>
+  )
+}
+
 export const getDropzoneText = ({ code, errors, filename }) => {
   let howToMessage =
     'To begin uploading a file, drag it into this box or click here.'
@@ -39,78 +50,59 @@ export const getDropzoneText = ({ code, errors, filename }) => {
   }
 
   if (filename) {
-    message = (
-      <div>
-        <p>
-          <strong>{filename}</strong> selected.
-        </p>
-        <p className="file-selected">{howToMessage}</p>
-      </div>
-    )
+    message = _getUploadMessage('', filename, 'selected.', howToMessage)
 
     if (code >= STATUS.UPLOADING && code <= STATUS.VALIDATING) {
-      message = (
-        <div>
-          <p>
-            Upload of <strong>{filename}</strong> is currently in progress.
-          </p>
-          <p className="file-selected">{howToMessage}</p>
-        </div>
+      message = _getUploadMessage(
+        'Upload of',
+        filename,
+        'is currently in progress.',
+        howToMessage
       )
     }
 
     if (code === STATUS.PARSED_WITH_ERRORS) {
-      message = (
-        <div>
-          <p>
-            Upload of <strong>{filename}</strong> has formatting errors.
-          </p>
-          <p className="file-selected">{howToMessage}</p>
-        </div>
+      message = _getUploadMessage(
+        'Upload of',
+        filename,
+        'has formatting errors.',
+        howToMessage
       )
     }
 
     if (code === STATUS.VALIDATED_WITH_ERRORS) {
-      message = (
-        <div>
-          <p>
-            Upload of <strong>{filename}</strong> is ready for review.
-          </p>
-          <p className="file-selected">{howToMessage}</p>
-        </div>
+      message = _getUploadMessage(
+        'Upload of',
+        filename,
+        'is ready for review.',
+        howToMessage
       )
     }
 
     if (code === STATUS.VALIDATED) {
-      message = (
-        <div>
-          <p>
-            Upload of <strong>{filename}</strong> is ready for submission.
-          </p>
-          <p className="file-selected">{howToMessage}</p>
-        </div>
+      message = _getUploadMessage(
+        'Upload of',
+        filename,
+        'is ready for submission.',
+        howToMessage
       )
     }
 
     if (code === STATUS.SIGNED) {
-      message = (
-        <div>
-          <p>
-            Your submission of <strong>{filename}</strong> is complete.
-          </p>
-          <p className="file-selected">{howToMessage}</p>
-        </div>
+      message = _getUploadMessage(
+        'Your submission of',
+        filename,
+        'is complete.',
+        howToMessage
       )
     }
 
     if (errors.length > 0) {
-      message = (
-        <div>
-          <p>
-            <strong>{filename}</strong> can not be uploaded.
-          </p>
-          <p>{howToMessage}</p>
-        </div>
+      message = _getUploadMessage(
+        '',
+        filename,
+        'can not be uploaded.',
+        howToMessage
       )
     }
   }

--- a/src/js/components/UploadForm.jsx
+++ b/src/js/components/UploadForm.jsx
@@ -2,10 +2,10 @@ import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import ValidationProgress from './ValidationProgress.jsx'
 import Dropzone from 'react-dropzone'
-import { CREATED, UPLOADING, SIGNED } from '../constants/statusCodes.js'
+import * as STATUS from '../constants/statusCodes.js'
 
 export const renderValidationProgress = ({ code, uploading, file, id }) => {
-  if (code < UPLOADING && !uploading) return null
+  if (code < STATUS.UPLOADING && !uploading) return null
   return <ValidationProgress file={file} code={code} id={id} />
 }
 
@@ -28,23 +28,14 @@ export const renderErrors = errors => {
 export const getDropzoneText = ({ code, errors, filename }) => {
   let howToMessage =
     'To begin uploading a file, drag it into this box or click here.'
-  if (code >= CREATED) {
+  if (code >= STATUS.CREATED) {
     howToMessage =
       'To begin uploading a new file, drag it into this box or click here.'
   }
   let message = <p>{howToMessage}</p>
 
-  if (code >= UPLOADING) {
+  if (code >= STATUS.UPLOADING) {
     message = howToMessage
-  }
-
-  if (code === SIGNED) {
-    message = (
-      <div>
-        <p>Your submission is complete.</p>
-        <p className="file-selected">{howToMessage}</p>
-      </div>
-    )
   }
 
   if (filename) {
@@ -57,6 +48,61 @@ export const getDropzoneText = ({ code, errors, filename }) => {
       </div>
     )
 
+    if (code >= STATUS.UPLOADING && code <= STATUS.VALIDATING) {
+      message = (
+        <div>
+          <p>
+            Upload of <strong>{filename}</strong> is currently in progress.
+          </p>
+          <p className="file-selected">{howToMessage}</p>
+        </div>
+      )
+    }
+
+    if (code === STATUS.PARSED_WITH_ERRORS) {
+      message = (
+        <div>
+          <p>
+            Upload of <strong>{filename}</strong> has formatting errors.
+          </p>
+          <p className="file-selected">{howToMessage}</p>
+        </div>
+      )
+    }
+
+    if (code === STATUS.VALIDATED_WITH_ERRORS) {
+      message = (
+        <div>
+          <p>
+            Upload of <strong>{filename}</strong> is ready for review.
+          </p>
+          <p className="file-selected">{howToMessage}</p>
+        </div>
+      )
+    }
+
+    if (code === STATUS.VALIDATED) {
+      message = (
+        <div>
+          <p>
+            Upload of <strong>{filename}</strong> is ready for submission.
+          </p>
+          <p className="file-selected">{howToMessage}</p>
+        </div>
+      )
+    }
+
+    if (code === STATUS.SIGNED) {
+      message = (
+        <div>
+          <p>
+            Your submission of <strong>{filename}</strong> is complete.
+          </p>
+          <p className="file-selected">{howToMessage}</p>
+        </div>
+      )
+    }
+
     if (errors.length > 0) {
       message = (
         <div>
@@ -64,28 +110,6 @@ export const getDropzoneText = ({ code, errors, filename }) => {
             <strong>{filename}</strong> can not be uploaded.
           </p>
           <p>{howToMessage}</p>
-        </div>
-      )
-    }
-
-    if (code >= UPLOADING) {
-      message = (
-        <div>
-          <p>
-            Submission of <strong>{filename}</strong> is currently in progess.
-          </p>
-          <p className="file-selected">{howToMessage}</p>
-        </div>
-      )
-    }
-
-    if (code === SIGNED) {
-      message = (
-        <div>
-          <p>
-            Your submission of <strong>{filename}</strong> is complete.
-          </p>
-          <p className="file-selected">{howToMessage}</p>
         </div>
       )
     }
@@ -102,7 +126,7 @@ export default class Upload extends Component {
     this.onDrop = acceptedFiles => {
       const { code, showConfirmModal, setFile, setNewFile } = this.props
 
-      if (code >= UPLOADING) {
+      if (code >= STATUS.UPLOADING) {
         showConfirmModal()
         setNewFile(acceptedFiles)
       } else {
@@ -112,7 +136,7 @@ export default class Upload extends Component {
   }
 
   componentDidMount() {
-    if (this.props.code >= UPLOADING) this.props.pollSubmission()
+    if (this.props.code >= STATUS.UPLOADING) this.props.pollSubmission()
   }
 
   render() {
@@ -126,7 +150,7 @@ export default class Upload extends Component {
             multiple={false}
             className="dropzone"
           >
-            {dropzoneText}
+            {getDropzoneText(this.props)}
           </Dropzone>
         </section>
         {renderValidationProgress(this.props)}

--- a/src/js/components/UploadForm.jsx
+++ b/src/js/components/UploadForm.jsx
@@ -2,26 +2,22 @@ import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import ValidationProgress from './ValidationProgress.jsx'
 import Dropzone from 'react-dropzone'
-import {
-  CREATED,
-  UPLOADING,
-  SIGNED
-} from '../constants/statusCodes.js'
+import { CREATED, UPLOADING, SIGNED } from '../constants/statusCodes.js'
 
-export const renderValidationProgress = (props) => {
-  if(props.code < UPLOADING && !props.uploading) return null
-  return <ValidationProgress file={props.file} code={props.code} id={props.id}/>
+export const renderValidationProgress = ({ code, uploading, file, id }) => {
+  if (code < UPLOADING && !uploading) return null
+  return <ValidationProgress file={file} code={code} id={id} />
 }
 
-export const renderErrors = (errors) => {
-  if(errors.length === 0) return null
+export const renderErrors = errors => {
+  if (errors.length === 0) return null
 
-  return(
+  return (
     <div className="usa-alert usa-alert-error" role="alert">
       <div className="usa-alert-body">
         <ul className="usa-alert-text">
           {errors.map((error, i) => {
-            return(<li key={i}>{error}</li>)
+            return <li key={i}>{error}</li>
           })}
         </ul>
       </div>
@@ -30,52 +26,72 @@ export const renderErrors = (errors) => {
 }
 
 export const getDropzoneText = ({ code, errors, filename }) => {
-  let howToMessage = 'To begin uploading a file, drag it into this box or click here.'
-  if(code >= CREATED) {
-    howToMessage = 'To begin uploading a new file, drag it into this box or click here.'
+  let howToMessage =
+    'To begin uploading a file, drag it into this box or click here.'
+  if (code >= CREATED) {
+    howToMessage =
+      'To begin uploading a new file, drag it into this box or click here.'
   }
   let message = <p>{howToMessage}</p>
 
-  if(code >= UPLOADING) {
+  if (code >= UPLOADING) {
     message = howToMessage
   }
 
-  if(code === SIGNED) {
-    message = <div>
-      <p>Your submission is complete.</p>
-      <p className="file-selected">{howToMessage}</p>
-    </div>
-  }
-
-  if(filename) {
-    message = <div>
-      <p><strong>{filename}</strong> selected.</p>
-      <p className="file-selected">{howToMessage}</p>
-    </div>
-
-    if(errors.length > 0) {
-      message = <div>
-        <p><strong>{filename}</strong> can not be uploaded.</p>
-        <p>{howToMessage}</p>
-      </div>
-    }
-
-    if(code >= UPLOADING) {
-      message = <div>
-        <p>Submission of <strong>{filename}</strong> is currently in progess.</p>
+  if (code === SIGNED) {
+    message = (
+      <div>
+        <p>Your submission is complete.</p>
         <p className="file-selected">{howToMessage}</p>
       </div>
-    }
+    )
+  }
 
-    if(code === SIGNED) {
-      message = <div>
-        <p>Your submission of <strong>{filename}</strong> is complete.</p>
+  if (filename) {
+    message = (
+      <div>
+        <p>
+          <strong>{filename}</strong> selected.
+        </p>
         <p className="file-selected">{howToMessage}</p>
       </div>
+    )
+
+    if (errors.length > 0) {
+      message = (
+        <div>
+          <p>
+            <strong>{filename}</strong> can not be uploaded.
+          </p>
+          <p>{howToMessage}</p>
+        </div>
+      )
+    }
+
+    if (code >= UPLOADING) {
+      message = (
+        <div>
+          <p>
+            Submission of <strong>{filename}</strong> is currently in progess.
+          </p>
+          <p className="file-selected">{howToMessage}</p>
+        </div>
+      )
+    }
+
+    if (code === SIGNED) {
+      message = (
+        <div>
+          <p>
+            Your submission of <strong>{filename}</strong> is complete.
+          </p>
+          <p className="file-selected">{howToMessage}</p>
+        </div>
+      )
     }
   }
 
-  return <button onClick={e=>e.preventDefault()}>{message}</button>
+  return <button onClick={e => e.preventDefault()}>{message}</button>
 }
 
 export default class Upload extends Component {
@@ -84,14 +100,9 @@ export default class Upload extends Component {
 
     // handle the onDrop to set the file and show confirmation modal
     this.onDrop = acceptedFiles => {
-      const {
-        code,
-        showConfirmModal,
-        setFile,
-        setNewFile
-      } = this.props
+      const { code, showConfirmModal, setFile, setNewFile } = this.props
 
-      if(code >= UPLOADING) {
+      if (code >= UPLOADING) {
         showConfirmModal()
         setNewFile(acceptedFiles)
       } else {
@@ -100,14 +111,11 @@ export default class Upload extends Component {
     }
   }
 
-  // keeps the info about the file after leaving /upload and coming back
   componentDidMount() {
-    if(this.props.code >= UPLOADING) this.props.pollSubmission()
+    if (this.props.code >= UPLOADING) this.props.pollSubmission()
   }
 
   render() {
-    const dropzoneText = getDropzoneText(this.props)
-
     return (
       <section className="UploadForm">
         {renderErrors(this.props.errors)}
@@ -116,7 +124,8 @@ export default class Upload extends Component {
             disablePreview={true}
             onDrop={this.onDrop}
             multiple={false}
-            className="dropzone">
+            className="dropzone"
+          >
             {dropzoneText}
           </Dropzone>
         </section>

--- a/src/js/containers/UploadForm.jsx
+++ b/src/js/containers/UploadForm.jsx
@@ -8,16 +8,11 @@ import pollForProgress from '../actions/pollForProgress.js'
 import * as Poller from '../actions/Poller.js'
 
 export function mapStateToProps(state) {
-
   const id = state.app.institution.id
   const code = state.app.submission.status.code
   const filename = state.app.submission.filename
 
-  const {
-    uploading,
-    file,
-    errors
-  } = state.app.upload[id] || {
+  const { uploading, file, errors } = state.app.upload[id] || {
     uploading: false,
     file: null,
     newFile: null,
@@ -36,14 +31,14 @@ export function mapStateToProps(state) {
 
 export function mapDispatchToProps(dispatch) {
   return {
-    setFile: (acceptedFiles) => {
-      if(!acceptedFiles) return
+    setFile: acceptedFiles => {
+      if (!acceptedFiles) return
       dispatch(selectFile(acceptedFiles[0]))
       dispatch(fetchUpload(acceptedFiles[0]))
     },
 
-    setNewFile: (acceptedFiles) => {
-      if(!acceptedFiles) return
+    setNewFile: acceptedFiles => {
+      if (!acceptedFiles) return
       dispatch(selectNewFile(acceptedFiles[0]))
     },
 


### PR DESCRIPTION
Closes #780

I used "upload" for most of this to show that the current file is in progress. I changed it to "submission" after it has been signed to show that the whole process is complete.

@designlanguage @wpears have a look and let me know what you think.

A few screenshots ...

### Intially
![upload-initial](https://user-images.githubusercontent.com/2932572/30913880-b39fef30-a35f-11e7-873e-482b8a88f4f2.png)

---

### Upload in progress
![upload-in-progress](https://user-images.githubusercontent.com/2932572/30913883-bb2b68ba-a35f-11e7-9562-fc9b52270e54.png)

---

### With formatting errors
![upload-formatting](https://user-images.githubusercontent.com/2932572/30913969-fae2665c-a35f-11e7-8e3a-b1111f7dd1f0.png)

---

### With edits
![upload-with-edits](https://user-images.githubusercontent.com/2932572/30913892-c156f682-a35f-11e7-8853-fab42ab43da1.png)

---

### Ready for signature
![upload-ready-for-sign](https://user-images.githubusercontent.com/2932572/30913912-cf74458a-a35f-11e7-9ac9-44d4ae165b46.png)

---

### Signed
![upload-signed](https://user-images.githubusercontent.com/2932572/30913916-d6850cb0-a35f-11e7-9b5d-05d6556cbe11.png)


