### PR TITLE
Browsers

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -2,6 +2,7 @@
   "presets": [
     "react",
     ["env", {
+      "modules": false,
       "useBuiltIns": "entry",
       "targets": {
         "browsers": [
@@ -11,7 +12,8 @@
            'Edge >= 15',
            'ie >= 11'
          ]
-      }
+      },
+      "debug": true
     }]
   ],
   "plugins": [

--- a/.babelrc
+++ b/.babelrc
@@ -2,7 +2,6 @@
   "presets": [
     "react",
     ["env", {
-      "modules": false,
       "useBuiltIns": "entry",
       "targets": {
         "browsers": [
@@ -12,8 +11,7 @@
            'Edge >= 15',
            'ie >= 11'
          ]
-      },
-      "debug": true
+      }
     }]
   ],
   "plugins": [

--- a/.babelrc
+++ b/.babelrc
@@ -2,8 +2,8 @@
   "presets": [
     "react",
     ["env", {
+      "useBuiltIns": "entry",
       "targets": {
-        "useBuiltIns": "entry",
         "browsers": [
           'Chrome >= 60',
           'Safari >= 10.1',

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -24,14 +24,7 @@ module.exports = {
         path.resolve(__dirname, 'node_modules'),
       ],
       use: {
-        loader: 'babel-loader',
-        options: {
-          presets: [
-            ['env', {
-              modules: false
-            }],
-          ],
-        },
+        loader: 'babel-loader'
       },
     }],
   },

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -28,17 +28,7 @@ module.exports = {
         options: {
           presets: [
             ['env', {
-              modules: false,
-              useBuiltIns: true,
-              targets: {
-                browsers: [
-                  'Chrome >= 60',
-                  'Safari >= 10.1',
-                  'Firefox >= 54',
-                  'Edge >= 15',
-                  'ie >= 11'
-                ],
-              },
+              modules: false
             }],
           ],
         },

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -24,7 +24,15 @@ module.exports = {
         path.resolve(__dirname, 'node_modules'),
       ],
       use: {
-        loader: 'babel-loader'
+        loader: 'babel-loader',
+        options: {
+          presets: [
+            ['env', {
+              modules: false,
+              useBuiltIns: true
+            }],
+          ],
+        },
       },
     }],
   },


### PR DESCRIPTION
Just some cleanup to share the `browsers` ~~and other properties~~ from `.babelrc`.

With the official release of [`babel-preset-env` 2.0](https://github.com/babel/babel-preset-env/releases) we _should_ be able to remove the `browsers` property from `.babelrc` and only use `.browserlistrc`.

~~This also shrunk the build a bit too, from 925KB to 876KB ... so double check me!~~