### PR TITLE
Better pagination timing

### DIFF
--- a/__tests__/containers/Pagination.js
+++ b/__tests__/containers/Pagination.js
@@ -54,7 +54,12 @@ describe('Pagination Container', () => {
   it('maps state to props with proper defaults', () => {
     expect(
       mapStateToProps(
-        { app: { pagination: defaultPagination } },
+        {
+          app: {
+            pagination: defaultPagination,
+            parseErrors: { isFetching: false }
+          }
+        },
         { target: 'parseErrors' }
       )
     ).toEqual({ pagination: null })
@@ -63,7 +68,12 @@ describe('Pagination Container', () => {
   it('maps state properly when given a pagination object is present', () => {
     expect(
       mapStateToProps(
-        { app: { pagination: { parseErrors: pageObj } } },
+        {
+          app: {
+            pagination: { parseErrors: pageObj },
+            parseErrors: { isFetching: false }
+          }
+        },
         { target: 'parseErrors' }
       )
     ).toEqual({ pagination: pageObj })
@@ -72,7 +82,13 @@ describe('Pagination Container', () => {
   it('maps state to undefined when given an invalid target', () => {
     expect(
       mapStateToProps(
-        { app: { pagination: { parseErrors: pageObj } } },
+        {
+          app: {
+            pagination: { parseErrors: pageObj },
+            parseErrors: { isFetching: false },
+            edits: { rows: { argle: '123' } }
+          }
+        },
         { target: 'fake' }
       )
     ).toEqual({ pagination: undefined })
@@ -115,8 +131,15 @@ describe('Pagination Container', () => {
     const err = console.error
     console.error = jest.fn()
     const pagination = TestUtils.renderIntoDocument(
-      <Wrapper store={{ app: { pagination: defaultPagination } }}>
-        <Connected />
+      <Wrapper
+        store={{
+          app: {
+            pagination: defaultPagination,
+            edits: { rows: { argle: '123' } }
+          }
+        }}
+      >
+        <Connected target="argle" />
       </Wrapper>
     )
 

--- a/src/js/actions/fetchPage.js
+++ b/src/js/actions/fetchPage.js
@@ -11,22 +11,12 @@ export default function fetchPage(target, pathname) {
     dispatch(getPaginationRequestAction(target))
     return fetch({ pathname: pathname })
       .then(json => {
-        return new Promise(resolve => {
-          setTimeout(
-            () =>
-              resolve(
-                hasHttpError(json).then(hasError => {
-                  return hasHttpError(json).then(hasError => {
-                    if (hasError) {
-                      dispatch(receiveError(json))
-                      throw new Error(`${json.status}: ${json.statusText}`)
-                    }
-                    return dispatch(getPaginationReceiveAction(target, json))
-                  })
-                })
-              ),
-            500
-          )
+        return hasHttpError(json).then(hasError => {
+          if (hasError) {
+            dispatch(receiveError(json))
+            throw new Error(`${json.status}: ${json.statusText}`)
+          }
+          return dispatch(getPaginationReceiveAction(target, json))
         })
       })
       .catch(err => error(err))

--- a/src/js/components/IRSReport.jsx
+++ b/src/js/components/IRSReport.jsx
@@ -166,7 +166,7 @@ const renderErrorMessage = () => {
 }
 
 const IRSReport = props => {
-  if (props.isFetching) return <LoadingIcon />
+  if (props.isFetching && !props.paginationFade) return <LoadingIcon />
   if (!props.msas) return null
   // sometimes the back-end returns an empty array for the, "msas":[]
   const renderResponse =

--- a/src/js/containers/Edits.jsx
+++ b/src/js/containers/Edits.jsx
@@ -16,6 +16,24 @@ export class EditsContainer extends Component {
       this.props.dispatch(fetchEdits())
   }
 
+  didPaginationUpdate(oldFade, newFade) {
+    const nextKeys = Object.keys(newFade)
+
+    for (let i = 0; i < nextKeys.length; i++) {
+      if (oldFade[nextKeys[i]] !== newFade[nextKeys[i]]) return true
+    }
+
+    return false
+  }
+
+  shouldComponentUpdate(nextProps) {
+    if (!Object.keys(nextProps.paginationFade).length) return true
+    return this.didPaginationUpdate(
+      this.props.paginationFade,
+      nextProps.paginationFade
+    )
+  }
+
   render() {
     return <EditsTableWrapper {...this.props} />
   }

--- a/src/js/containers/IRSReport.jsx
+++ b/src/js/containers/IRSReport.jsx
@@ -19,6 +19,11 @@ export class IRSReportContainer extends Component {
     this.props.dispatch(cancelIRSFetch())
   }
 
+  shouldComponentUpdate(nextProps) {
+    if (this.props.paginationFade !== nextProps.paginationFade) return true
+    return !nextProps.paginationFade
+  }
+
   render() {
     return <IRSReport {...this.props} />
   }

--- a/src/js/containers/Pagination.jsx
+++ b/src/js/containers/Pagination.jsx
@@ -23,9 +23,13 @@ function mapStateToProps(state, ownProps) {
   let isFetching
 
   if (stateTarget !== 'parseErrors' && stateTarget !== 'irs') {
-    isFetching = state.app.edits.rows[stateTarget].isFetching
+    if (state.app.edits.rows[stateTarget]) {
+      isFetching = state.app.edits.rows[stateTarget].isFetching
+    }
   } else {
-    isFetching = state.app[stateTarget].isFetching
+    if (state.app[stateTarget]) {
+      isFetching = state.app[stateTarget].isFetching
+    }
   }
 
   fetchChecker[ownProps.target] = isFetching

--- a/src/js/containers/Pagination.jsx
+++ b/src/js/containers/Pagination.jsx
@@ -19,6 +19,16 @@ class PaginationContainer extends Component {
 }
 
 function mapStateToProps(state, ownProps) {
+  const stateTarget = ownProps.target
+  let isFetching
+
+  if (stateTarget !== 'parseErrors' && stateTarget !== 'irs') {
+    isFetching = state.app.edits.rows[stateTarget].isFetching
+  } else {
+    isFetching = state.app[stateTarget].isFetching
+  }
+
+  fetchChecker[ownProps.target] = isFetching
   return {
     pagination: state.app.pagination[ownProps.target]
   }
@@ -36,8 +46,6 @@ function fetchAndFade(dispatch, target, pagination, link) {
 }
 
 function mapDispatchToProps(dispatch, ownProps) {
-  fetchChecker[ownProps.target] = ownProps.isFetching
-
   return {
     getPage: (pagination, page) => {
       if (!pagination || page === undefined) return

--- a/src/js/containers/ParseErrors.jsx
+++ b/src/js/containers/ParseErrors.jsx
@@ -17,6 +17,11 @@ export class ParseErrorsContainer extends Component {
       this.props.dispatch(fetchParseErrors())
   }
 
+  shouldComponentUpdate(nextProps) {
+    if (this.props.paginationFade !== nextProps.paginationFade) return true
+    return !nextProps.paginationFade
+  }
+
   render() {
     return <ParseErrors {...this.props} />
   }


### PR DESCRIPTION
Rather than relying on a weird timeout to ensure smooth page transitions, just key off the paginationFade state