### PR TITLE
adding aria-hidden prevents odd spacing prior to using the accordions

### DIFF
--- a/src/js/components/InstitutionSubmissionHistory.jsx
+++ b/src/js/components/InstitutionSubmissionHistory.jsx
@@ -26,6 +26,7 @@ const InstitutionPreviousSubmissions = ({
           <div
             id={`submissions-${institutionId}`}
             className="usa-accordion-content"
+            aria-hidden="true"
           >
             <p>
               The edit report for previous submissions that completed the


### PR DESCRIPTION
Closes #883 

The problem was actually due to the accordions on `/institutions`.

So while a USWDS problem, not due to the upgrade. 