### PR TITLE
update message for s040 because we can't display the loan/application…

### DIFF
--- a/src/js/components/EditsTable.jsx
+++ b/src/js/components/EditsTable.jsx
@@ -62,11 +62,17 @@ export const renderTableCaption = (edit, rowObj, type, pagination) => {
       ? `Edit ${name} found.`
       : `${length} ${name} ${editText} found.`
 
-  if (type === 'macro') {
+  if (type === 'macro' || name === 'S040') {
     return (
       <div className="caption">
         <h3>{captionHeader}</h3>
         {description ? <p>{description}</p> : null}
+        {name === 'S040' ? (
+          <p>
+            Please check your file or system of record for duplicate
+            application/loan numbers.
+          </p>
+        ) : null}
       </div>
     )
   }
@@ -89,7 +95,7 @@ export const makeTable = props => {
   if (!rowObj || !rowObj.rows) return <LoadingIcon />
 
   const caption = renderTableCaption(edit, rowObj, type, pagination)
-  if (type === 'macro') return caption
+  if (type === 'macro' || name === 'S040') return caption
 
   let className = 'PaginationTarget'
   className += props.paginationFade[name] ? ' fadeOut' : ''

--- a/src/sass/components/_EditsTable.scss
+++ b/src/sass/components/_EditsTable.scss
@@ -34,6 +34,10 @@
       margin-bottom: 0;
     }
   }
+  .caption p {
+    font-size: .885em; // ~15px
+    font-weight: bold;
+  }
   &:last-of-type {
     margin-bottom: 2em;
   }


### PR DESCRIPTION
Closes #893 

@wpears - the CSS changes are because the descriptions were a bit different when the caption was within a table vs not in a table. 