### PR TITLE
Remove duplicated image background for loading icon

### DIFF
--- a/src/sass/components/_LoadingIcon.scss
+++ b/src/sass/components/_LoadingIcon.scss
@@ -5,7 +5,6 @@
 }
 
 .LoadingIcon {
-  background-image: url("/img/LoadingIcon.png");
   width: 3em;
   animation: loading-spin 2s infinite linear;
 }


### PR DESCRIPTION
The LoadingIcon is defined as an img, so this background image is duplicative. It was also causing the animation to be a bit janky and the loading icon to look sliiiiightly fuzzy.