### PR TITLE
WIP - Better warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "clearDist": "rimraf ./dist && mkdirp ./dist ./dist/js ./dist/css ./dist/fonts ./dist/img",
     "clearBackup": "rimraf ./dist/js/app.min.js.bak",
     "js": "(export NODE_ENV=build; webpack --progress)",
-    "js:dev": "(export NODE_ENV=build; webpack --config webpack.dev.js --progress)",
+    "js:dev": "export NODE_ENV=build && webpack --config webpack.dev.js --progress",
     "renew": "(export NODE_ENV=build; webpack --config webpack.renew.js --progress)",
     "sass": "node-sass --quiet --output-style=compressed --source-map=./dist/css/ ./src/app.scss ./dist/css/app.min.css && cp node_modules/uswds/src/fonts/sourcesanspro-* ./dist/fonts && yarn run sass:prefix",
     "sass:prefix": "postcss -u autoprefixer -r ./dist/css/*.css",

--- a/src/submission/Receipt.jsx
+++ b/src/submission/Receipt.jsx
@@ -4,7 +4,7 @@ import Alert from '../common/Alert.jsx'
 import { ordinalHour } from '../utils/date.js'
 import { SIGNED } from '../constants/statusCodes.js'
 
-const SubmissionReceipt = ({
+const Receipt = ({
   status,
   timestamp,
   receipt,
@@ -31,7 +31,7 @@ const SubmissionReceipt = ({
   )
 }
 
-SubmissionReceipt.propTypes = {
+Receipt.propTypes = {
   email: PropTypes.string,
   filingPeriod: PropTypes.string,
   receipt: PropTypes.string,
@@ -40,4 +40,4 @@ SubmissionReceipt.propTypes = {
   isFetching: PropTypes.bool
 }
 
-export default SubmissionReceipt
+export default Receipt

--- a/src/submission/Receipt.jsx
+++ b/src/submission/Receipt.jsx
@@ -15,17 +15,19 @@ const SubmissionReceipt = ({
   if (code !== SIGNED) return null
 
   return (
-    <Alert type="success" heading="HMDA filing accepted!">
-      <div>
-        Congratulations, you have successfully completed your HMDA filing for{' '}
-        {filingPeriod}!
-        <br />
-        Your data and signature were received and recorded on{' '}
-        <strong>{ordinalHour(new Date(timestamp))}</strong>.
-        <br />
-        Your receipt number for this submission is <strong>{receipt}</strong>.
-      </div>
-    </Alert>
+    <section className="RefileWarning">
+      <Alert type="success" heading="HMDA filing accepted!">
+        <div>
+          Congratulations, you have successfully completed your HMDA filing for{' '}
+          {filingPeriod}!
+          <br />
+          Your data and signature were received and recorded on{' '}
+          <strong>{ordinalHour(new Date(timestamp))}</strong>.
+          <br />
+          Your receipt number for this submission is <strong>{receipt}</strong>.
+        </div>
+      </Alert>
+    </section>
   )
 }
 

--- a/src/submission/Receipt.jsx
+++ b/src/submission/Receipt.jsx
@@ -12,8 +12,7 @@ const Receipt = ({
   email
 }) => {
   const code = status.code
-  if (code !== SIGNED) return null
-
+  if (code !== SIGNED || receipt === null) return null
   return (
     <section className="RefileWarning">
       <Alert type="success" heading="HMDA filing accepted!">

--- a/src/submission/Receipt.test.js
+++ b/src/submission/Receipt.test.js
@@ -36,21 +36,21 @@ describe('Receipt component', () => {
   })
 
   it('has the correct filingPeriod', () => {
-    /*expect(
+    expect(
       TestUtils.scryRenderedDOMComponentsWithTag(
         receipt,
-        'p'
+        'div'
       )[0].textContent.match('2017')
-    ).toBeTruthy()*/
+    ).toBeTruthy()
   })
 
-  it('has the correct email', () => {
-    /*expect(
+  it('has the correct receipt', () => {
+    expect(
       TestUtils.scryRenderedDOMComponentsWithTag(
         receipt,
-        'p'
-      )[3].textContent.match('yo@me.com')
-    ).toBeTruthy()*/
+        'strong'
+      )[1].textContent.match('fee-fi-fo-fum')
+    ).toBeTruthy()
   })
 
   const unsigned = TestUtils.renderIntoDocument(

--- a/src/submission/ReceiptContainer.jsx
+++ b/src/submission/ReceiptContainer.jsx
@@ -2,9 +2,9 @@ import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 import fetchSignature from '../actions/fetchSignature.js'
-import SubmissionReceipt from './Receipt.jsx'
+import Receipt from './Receipt.jsx'
 
-export class SubmissionReceiptContainer extends Component {
+export class ReceiptContainer extends Component {
   constructor(props) {
     super(props)
   }
@@ -15,7 +15,7 @@ export class SubmissionReceiptContainer extends Component {
   }
 
   render() {
-    return <SubmissionReceipt {...this.props} />
+    return <Receipt {...this.props} />
   }
 }
 
@@ -44,5 +44,5 @@ export function mapDispatchToProps(dispatch) {
 }
 
 export default connect(mapStateToProps, mapDispatchToProps)(
-  SubmissionReceiptContainer
+  ReceiptContainer
 )

--- a/src/submission/ReceiptContainer.jsx
+++ b/src/submission/ReceiptContainer.jsx
@@ -4,23 +4,8 @@ import { connect } from 'react-redux'
 import fetchSignature from '../actions/fetchSignature.js'
 import Receipt from './Receipt.jsx'
 
-export class ReceiptContainer extends Component {
-  constructor(props) {
-    super(props)
-  }
-
-  componentDidMount() {
-    if (!this.props.isFetching && this.props.receipt === null)
-      this.props.dispatch(fetchSignature())
-  }
-
-  render() {
-    return <Receipt {...this.props} />
-  }
-}
-
 export function mapStateToProps(state) {
-  const { isFetching, timestamp, receipt } = state.app.signature
+  const { timestamp, receipt } = state.app.signature
 
   const { status } = state.app.submission
   const { email } = state.app.user.oidc.profile
@@ -28,7 +13,6 @@ export function mapStateToProps(state) {
   const { filingPeriod } = state.app
 
   return {
-    isFetching,
     timestamp,
     receipt,
     status,
@@ -37,12 +21,4 @@ export function mapStateToProps(state) {
   }
 }
 
-export function mapDispatchToProps(dispatch) {
-  return {
-    dispatch
-  }
-}
-
-export default connect(mapStateToProps, mapDispatchToProps)(
-  ReceiptContainer
-)
+export default connect(mapStateToProps)(Receipt)

--- a/src/submission/container.jsx
+++ b/src/submission/container.jsx
@@ -6,11 +6,11 @@ import fetchSubmission from '../actions/fetchSubmission.js'
 import fetchInstitution from '../actions/fetchInstitution.js'
 import setFilename from '../actions/setFilename.js'
 import UserHeading from './UserHeading.jsx'
-import SubmissionPageInfo from './ReadyToSign.jsx'
+import ReadyToSign from './ReadyToSign.jsx'
 import UploadForm from './upload/container.jsx'
 import ErrorWarning from '../common/ErrorWarning.jsx'
 import EditsContainer from './edits/container.jsx'
-import SubmissionReceipt from './ReceiptContainer.jsx'
+import ReceiptContainer from './ReceiptContainer.jsx'
 import EditsNavComponent from './Nav.jsx'
 import NavButtonComponent from './NavButton.jsx'
 import RefileWarningContainer from '../refileWarning/container.jsx'
@@ -52,9 +52,9 @@ const renderByCode = (code, page, message) => {
       let warningOrReceipt = null
 
       if (code !== SIGNED) {
-        warningOrReceipt = <SubmissionPageInfo />
+        warningOrReceipt = <ReadyToSign />
       } else {
-        warningOrReceipt = <SubmissionReceipt />
+        warningOrReceipt = <ReceiptContainer />
       }
 
       // at the top of the page

--- a/src/submission/container.jsx
+++ b/src/submission/container.jsx
@@ -54,11 +54,7 @@ const renderByCode = (code, page, message) => {
       if (code !== SIGNED) {
         warningOrReceipt = <SubmissionPageInfo />
       } else {
-        warningOrReceipt = (
-          <section className="RefileWarning">
-            <SubmissionReceipt />
-          </section>
-        )
+        warningOrReceipt = <SubmissionReceipt />
       }
 
       // at the top of the page

--- a/src/submission/container.jsx
+++ b/src/submission/container.jsx
@@ -47,18 +47,18 @@ const renderByCode = (code, page, message) => {
     } else if (
       ['syntacticalvalidity', 'quality', 'macro'].indexOf(page) !== -1
     ) {
-      if (code > VALIDATING) {
-        toRender.push(<Edits />)
-      }
+      toRender.push(<Edits />)
     } else if (page === 'submission') {
       let warningOrReceipt = null
 
       if (code !== SIGNED) {
         warningOrReceipt = <SubmissionPageInfo />
       } else {
-        warningOrReceipt = <section className="RefileWarning">
-                <SubmissionReceipt />
-              </section>
+        warningOrReceipt = (
+          <section className="RefileWarning">
+            <SubmissionReceipt />
+          </section>
+        )
       }
 
       // at the top of the page
@@ -127,7 +127,6 @@ class SubmissionContainer extends Component {
         <EditsNav />
         <main id="main-content" className="usa-grid SubmissionContainer">
           {this.props.error ? <ErrorWarning error={this.props.error} /> : null}
-          {code !== PARSED_WITH_ERRORS ? <RefileWarning /> : null}
           {toRender.map((component, i) => {
             return (
               <div className="usa-width-one-whole" key={i}>

--- a/src/submission/container.jsx
+++ b/src/submission/container.jsx
@@ -51,11 +51,23 @@ const renderByCode = (code, page, message) => {
         toRender.push(<Edits />)
       }
     } else if (page === 'submission') {
-      if (code > VALIDATING) {
-        toRender.push(<IRSReport />)
-        toRender.push(<Summary />)
-        toRender.push(<Signature />)
+      let warningOrReceipt = null
+
+      if (code !== SIGNED) {
+        warningOrReceipt = <SubmissionPageInfo />
+      } else {
+        warningOrReceipt = <section className="RefileWarning">
+                <SubmissionReceipt />
+              </section>
       }
+
+      // at the top of the page
+      toRender.push(warningOrReceipt)
+      toRender.push(<IRSReport />)
+      toRender.push(<Summary />)
+      // and just before the signature
+      toRender.push(warningOrReceipt)
+      toRender.push(<Signature />)
     }
   }
 
@@ -116,15 +128,6 @@ class SubmissionContainer extends Component {
         <main id="main-content" className="usa-grid SubmissionContainer">
           {this.props.error ? <ErrorWarning error={this.props.error} /> : null}
           {code !== PARSED_WITH_ERRORS ? <RefileWarning /> : null}
-          {page === 'submission' ? (
-            code !== SIGNED ? (
-              <SubmissionPageInfo />
-            ) : (
-              <section className="RefileWarning">
-                <SubmissionReceipt />
-              </section>
-            )
-          ) : null}
           {toRender.map((component, i) => {
             return (
               <div className="usa-width-one-whole" key={i}>

--- a/src/submission/container.jsx
+++ b/src/submission/container.jsx
@@ -13,7 +13,6 @@ import EditsContainer from './edits/container.jsx'
 import ReceiptContainer from './ReceiptContainer.jsx'
 import EditsNavComponent from './Nav.jsx'
 import NavButtonComponent from './NavButton.jsx'
-import RefileWarningContainer from '../refileWarning/container.jsx'
 import submissionProgressHOC from './progressHOC.jsx'
 import IRSReport from './irs/container.jsx'
 import Signature from './signature/container.jsx'
@@ -32,7 +31,6 @@ import {
 const Edits = submissionProgressHOC(EditsContainer)
 const EditsNav = submissionProgressHOC(EditsNavComponent)
 const NavButton = submissionProgressHOC(NavButtonComponent)
-const RefileWarning = submissionProgressHOC(RefileWarningContainer)
 
 const renderByCode = (code, page, message) => {
   const toRender = []
@@ -49,21 +47,19 @@ const renderByCode = (code, page, message) => {
     ) {
       toRender.push(<Edits />)
     } else if (page === 'submission') {
-      let warningOrReceipt = null
-
-      if (code !== SIGNED) {
-        warningOrReceipt = <ReadyToSign />
-      } else {
-        warningOrReceipt = <ReceiptContainer />
-      }
-
       // at the top of the page
-      toRender.push(warningOrReceipt)
+      if(code !== SIGNED) {
+        toRender.push(<ReadyToSign />)
+      }
+      toRender.push(<ReceiptContainer />)
       toRender.push(<IRSReport />)
       toRender.push(<Summary />)
       // and just before the signature
-      toRender.push(warningOrReceipt)
+      if(code !== SIGNED) {
+        toRender.push(<ReadyToSign />)
+      }
       toRender.push(<Signature />)
+      toRender.push(<ReceiptContainer />)
     }
   }
 

--- a/src/submission/edits/TableWrapper.jsx
+++ b/src/submission/edits/TableWrapper.jsx
@@ -79,7 +79,10 @@ const EditsTableWrapper = props => {
     loading
   ) : (
     <section className="EditsTableWrapper">
+      {/* warn at the top of the page */}
+      <RefileWarning />
       {makeEntry(props, type)}
+      {/* warn at the bottom of the page */}
       <RefileWarning />
       {type === 'quality' || type === 'macro' ? <Verifier type={type} /> : null}
       <hr />

--- a/src/submission/edits/TableWrapper.test.js
+++ b/src/submission/edits/TableWrapper.test.js
@@ -47,7 +47,7 @@ describe('EditsTableWrapper', () => {
     const rendered = EditsTableWrapper(localProps)
 
     // the number of tables rendered
-    expect(rendered.props.children[0].props.children[1].length).toBe(2)
+    expect(rendered.props.children[1].props.children[1].length).toBe(2)
   })
 
   it('does not render verifier on synval and renders 3 tables', () => {
@@ -58,8 +58,9 @@ describe('EditsTableWrapper', () => {
       page: 'syntacticalvalidity'
     }
     const rendered = EditsTableWrapper(localProps)
-    expect(rendered.props.children[0].props.children[1].length).toBe(3)
-    expect(rendered.props.children[2]).toBe(null)
+
+    expect(rendered.props.children[1].props.children[1].length).toBe(3)
+    expect(rendered.props.children[3]).toBe(null)
   })
 })
 

--- a/src/submission/signature/Signature.test.js
+++ b/src/submission/signature/Signature.test.js
@@ -5,8 +5,6 @@ import Wrapper from '../../../test-resources/Wrapper.js'
 import React from 'react'
 import ReactDOM from 'react-dom'
 import TestUtils from 'react-dom/test-utils'
-jest.mock('../ReceiptContainer.jsx')
-import SubmissionReceipt from '../ReceiptContainer.jsx'
 
 const fs = require('fs')
 const signJSON = JSON.parse(
@@ -46,15 +44,6 @@ describe('Signature component', () => {
     expect(
       TestUtils.scryRenderedDOMComponentsWithTag(signature, 'button').length
     ).toEqual(1)
-  })
-
-  it('does NOT render the receipt and hash', () => {
-    expect(
-      TestUtils.scryRenderedDOMComponentsWithClass(
-        signature,
-        'usa-alert-success'
-      ).length
-    ).toEqual(0)
   })
 
   it('has button disabled', () => {
@@ -129,10 +118,6 @@ describe('Signature component', () => {
   )
   const signatureSignedNode = ReactDOM.findDOMNode(signatureSigned)
 
-  it('renders the receipt', () => {
-    expect(SubmissionReceipt.mock.calls.length).toBe(4)
-  })
-
   it('has the checkbox checked', () => {
     const checkboxChecked = TestUtils.findRenderedDOMComponentWithTag(
       signatureSigned,
@@ -154,31 +139,6 @@ describe('Signature component', () => {
       TestUtils.findRenderedDOMComponentWithClass(
         signatureSigned,
         'usa-button-disabled'
-      )
-    ).toBeTruthy()
-  })
-
-  const statusEdits = {
-    code: 7,
-    message: ''
-  }
-  const signatureWithEdits = TestUtils.renderIntoDocument(
-    <Wrapper>
-      <Signature
-        checked={true}
-        status={statusEdits}
-        onSignatureClick={onSignatureClick}
-        onSignatureCheck={onSignatureCheck}
-      />
-    </Wrapper>
-  )
-  const signatureWithEditsNode = ReactDOM.findDOMNode(signatureWithEdits)
-
-  it('renders the warning', () => {
-    expect(
-      TestUtils.findRenderedDOMComponentWithClass(
-        signatureWithEdits,
-        'usa-alert-warning'
       )
     ).toBeTruthy()
   })

--- a/src/submission/signature/_Signature.scss
+++ b/src/submission/signature/_Signature.scss
@@ -1,6 +1,10 @@
 .Signature {
   margin-bottom: 5em;
 
+  h2 {
+    margin-top: 0;
+  }
+
   .usa-font-lead {
     color: $color-gray-dark;
     margin-top: 0.5em;

--- a/src/submission/signature/index.jsx
+++ b/src/submission/signature/index.jsx
@@ -1,20 +1,11 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import ErrorWarning from '../../common/ErrorWarning.jsx'
-import SubmissionReceipt from '../ReceiptContainer.jsx'
-import SubmissionPageInfo from '../ReadyToSign.jsx'
 import Alert from '../../common/Alert.jsx'
 import { VALIDATED_WITH_ERRORS, SIGNED } from '../../constants/statusCodes.js'
 
-const showPageInfo = code => {
-  if (code > VALIDATED_WITH_ERRORS && code !== SIGNED)
-    return <SubmissionPageInfo />
-
-  return null
-}
-
 const showWarning = props => {
-  if (!props.error && props.status.code > VALIDATED_WITH_ERRORS) return null
+  if (!props.error) return null
 
   if (props.error)
     return (
@@ -23,15 +14,6 @@ const showWarning = props => {
         bodyText="You cannot sign your submission if you have encountered an error in the filing process. Please refresh the page or try again later."
       />
     )
-
-  return (
-    <Alert type="warning" heading="Edits still exist.">
-      <p>
-        You can not sign your submission until all edits have passed or been
-        verified.
-      </p>
-    </Alert>
-  )
 }
 
 const Signature = props => {
@@ -58,7 +40,6 @@ const Signature = props => {
 
   return (
     <section className="Signature" id="signature">
-      {showPageInfo(props.status.code)}
 
       <header>
         <h2>Signature</h2>
@@ -96,8 +77,6 @@ const Signature = props => {
       >
         Submit HMDA data
       </button>
-
-      <SubmissionReceipt />
     </section>
   )
 }

--- a/src/submission/signature/index.jsx
+++ b/src/submission/signature/index.jsx
@@ -6,14 +6,12 @@ import { VALIDATED_WITH_ERRORS, SIGNED } from '../../constants/statusCodes.js'
 
 const showWarning = props => {
   if (!props.error) return null
-
-  if (props.error)
-    return (
-      <ErrorWarning
-        error={props.error}
-        bodyText="You cannot sign your submission if you have encountered an error in the filing process. Please refresh the page or try again later."
-      />
-    )
+  return (
+    <ErrorWarning
+      error={props.error}
+      bodyText="You cannot sign your submission if you have encountered an error in the filing process. Please refresh the page or try again later."
+    />
+  )
 }
 
 const Signature = props => {
@@ -40,7 +38,6 @@ const Signature = props => {
 
   return (
     <section className="Signature" id="signature">
-
       <header>
         <h2>Signature</h2>
         <p className="usa-font-lead">

--- a/test-resources/json/receipt.json
+++ b/test-resources/json/receipt.json
@@ -1,4 +1,4 @@
 {
-  "timestamp": null,
-  "receipt": null
+  "timestamp": 1516936164711,
+  "receipt": "fee-fi-fo-fum"
 }


### PR DESCRIPTION
### WIP

__Depends on #996 and #998__

Closes #989 
Closes #990 

For the edit warnings, I moved the rendering into the `tableWrapper`. They wouldn't work all in the submission `container` because of the rendering of the verifier, which also happens in the `tableWrapper`.

For the `pageInfo` and `receipt` on the submission page, I moved those all into the submission `container` because there are multiple components rendered on that page. 

I've also removed some of the logic where we checked for `status` in the submission `container`. We shouldn't need to do that because those pages can't be accessed unless that status was true already. I imagine it was another piece that was just lingering from the old way of doing it.