### PR TITLE
Refactor api signatures

### DIFF
--- a/src/actions/Submission.js
+++ b/src/actions/Submission.js
@@ -1,9 +1,0 @@
-let id
-
-export function getId() {
-  return id
-}
-
-export function setId(newId) {
-  return (id = newId)
-}

--- a/src/actions/Submission.test.js
+++ b/src/actions/Submission.test.js
@@ -1,8 +1,0 @@
-jest.unmock('./Submission.js')
-jest.unmock('../constants')
-import * as types from '../constants'
-import Submission from './Submission.js'
-
-describe('Submission', () => {
-  it('is mocked', () => {})
-})

--- a/src/actions/fetchEditType.js
+++ b/src/actions/fetchEditType.js
@@ -5,7 +5,6 @@ import receiveEditType from './receiveEditType.js'
 import receiveError from './receiveError.js'
 import hasHttpError from './hasHttpError.js'
 import { getEdit } from '../api/api.js'
-import { getId } from './Submission.js'
 import { error } from '../utils/log.js'
 
 export default function fetchEditType(type) {
@@ -16,7 +15,7 @@ export default function fetchEditType(type) {
     editTypes[type].edits.forEach(edit => {
       dispatch(requestEdit(edit.edit))
       promises.push(
-        getEdit({ submission: getId(), edit: edit.edit })
+        getEdit({ edit: edit.edit })
           .then(json => {
             return hasHttpError(json).then(hasError => {
               if (hasError) {

--- a/src/actions/fetchEdits.js
+++ b/src/actions/fetchEdits.js
@@ -2,14 +2,13 @@ import requestEdits from './requestEdits.js'
 import hasHttpError from './hasHttpError.js'
 import receiveError from './receiveError.js'
 import receiveEdits from './receiveEdits.js'
-import { getId } from './Submission.js'
 import { getEdits } from '../api/api.js'
 import { error } from '../utils/log.js'
 
 export default function fetchEdits() {
   return dispatch => {
     dispatch(requestEdits())
-    return getEdits({ submission: getId() })
+    return getEdits()
       .then(json => {
         return hasHttpError(json).then(hasError => {
           if (hasError) {

--- a/src/actions/fetchIRS.js
+++ b/src/actions/fetchIRS.js
@@ -1,7 +1,6 @@
 import receiveIRS from './receiveIRS.js'
 import receiveError from './receiveError.js'
 import hasHttpError from './hasHttpError.js'
-import { getId } from './Submission.js'
 import requestIRS from './requestIRS.js'
 import * as IRSPollingId from './IRSPollingId.js'
 import { getIRS } from '../api/api.js'
@@ -11,7 +10,7 @@ export default function fetchIRS() {
   return dispatch => {
     dispatch(requestIRS())
     const poller = () => {
-      return getIRS(getId())
+      return getIRS()
         .then(json => {
           return hasHttpError(json).then(hasError => {
             if (hasError) {

--- a/src/actions/fetchParseErrors.js
+++ b/src/actions/fetchParseErrors.js
@@ -2,14 +2,13 @@ import receiveParseErrors from './receiveParseErrors.js'
 import receiveError from './receiveError.js'
 import hasHttpError from './hasHttpError.js'
 import requestParseErrors from './requestParseErrors.js'
-import { getId } from './Submission.js'
 import { getParseErrors } from '../api/api.js'
 import { error } from '../utils/log.js'
 
 export default function fetchParseErrors() {
   return dispatch => {
     dispatch(requestParseErrors())
-    return getParseErrors(getId())
+    return getParseErrors()
       .then(json => {
         return hasHttpError(json).then(hasError => {
           if (hasError) {

--- a/src/actions/fetchSignature.js
+++ b/src/actions/fetchSignature.js
@@ -1,7 +1,6 @@
 import receiveSignature from './receiveSignature.js'
 import receiveError from './receiveError.js'
 import hasHttpError from './hasHttpError.js'
-import { getId } from './Submission.js'
 import requestSignature from './requestSignature.js'
 import { getSignature } from '../api/api.js'
 import { error } from '../utils/log.js'
@@ -9,7 +8,7 @@ import { error } from '../utils/log.js'
 export default function fetchSignature() {
   return dispatch => {
     dispatch(requestSignature())
-    return getSignature(getId())
+    return getSignature()
       .then(json => {
         return hasHttpError(json).then(hasError => {
           if (hasError) {

--- a/src/actions/fetchSummary.js
+++ b/src/actions/fetchSummary.js
@@ -1,7 +1,6 @@
 import receiveSummary from './receiveSummary.js'
 import receiveError from './receiveError.js'
 import hasHttpError from './hasHttpError.js'
-import { getId } from './Submission.js'
 import requestSummary from './requestSummary.js'
 import { getSummary } from '../api/api.js'
 import { error } from '../utils/log.js'
@@ -9,7 +8,7 @@ import { error } from '../utils/log.js'
 export default function fetchSummary() {
   return dispatch => {
     dispatch(requestSummary())
-    return getSummary(getId())
+    return getSummary()
       .then(json => {
         return hasHttpError(json).then(hasError => {
           if (hasError) {

--- a/src/actions/fetchUpload.js
+++ b/src/actions/fetchUpload.js
@@ -1,4 +1,3 @@
-import { getId } from './Submission.js'
 import * as Poller from './Poller.js'
 import { postUpload } from '../api/api.js'
 import pollForProgress from './pollForProgress.js'
@@ -16,7 +15,7 @@ export default function fetchUpload(file) {
     const data = new FormData()
     data.append('file', file)
 
-    return postUpload(getId(), data)
+    return postUpload(data)
       .then(json => {
         return hasHttpError(json).then(hasError => {
           if (hasError) {

--- a/src/actions/fetchVerify.js
+++ b/src/actions/fetchVerify.js
@@ -5,7 +5,6 @@ import verifyMacro from './verifyMacro.js'
 import verifyQuality from './verifyQuality.js'
 import receiveError from './receiveError.js'
 import hasHttpError from './hasHttpError.js'
-import { getId } from './Submission.js'
 import { postVerify } from '../api/api.js'
 import { error } from '../utils/log.js'
 
@@ -14,7 +13,7 @@ export default function fetchVerify(type, checked) {
     if (type === 'quality') dispatch(requestVerifyQuality())
     else dispatch(requestVerifyMacro())
 
-    return postVerify(getId(), type, checked)
+    return postVerify(type, checked)
       .then(json => {
         return hasHttpError(json).then(hasError => {
           if (hasError) {

--- a/src/actions/receiveSubmission.js
+++ b/src/actions/receiveSubmission.js
@@ -1,8 +1,6 @@
 import * as types from '../constants'
-import { setId } from './Submission.js'
 
 export default function receiveSubmission(data) {
-  setId(data.id.sequenceNumber)
 
   return {
     type: types.RECEIVE_SUBMISSION,

--- a/src/actions/updateSignature.js
+++ b/src/actions/updateSignature.js
@@ -2,7 +2,6 @@ import updateStatus from './updateStatus.js'
 import receiveSignaturePost from './receiveSignaturePost.js'
 import receiveError from './receiveError.js'
 import hasHttpError from './hasHttpError.js'
-import { getId } from './Submission.js'
 import requestSignaturePost from './requestSignaturePost.js'
 import { postSignature } from '../api/api.js'
 import { error } from '../utils/log.js'
@@ -10,7 +9,7 @@ import { error } from '../utils/log.js'
 export default function updateSignature(signed) {
   return dispatch => {
     dispatch(requestSignaturePost())
-    return postSignature(getId(), signed)
+    return postSignature(signed)
       .then(json => {
         return hasHttpError(json).then(hasError => {
           if (hasError) {

--- a/src/api/api.js
+++ b/src/api/api.js
@@ -23,14 +23,12 @@ export function getLatestSubmission() {
   return fetch({ submission: 'latest' })
 }
 
-export function getEdits(pathObj) {
-  pathObj.suffix = pathObj.suffix ? pathObj.suffix : '/edits'
-  return fetch(pathObj)
+export function getEdits() {
+  return fetch({ suffix: '/edits' })
 }
 
 export function getEdit(pathObj) {
-  pathObj.suffix = pathObj.suffix ? pathObj.suffix : `/edits/${pathObj.edit}`
-  return fetch(pathObj)
+  return fetch({ suffix: `/edits/${pathObj.edit}` })
 }
 
 export function getCSV(pathObj) {
@@ -45,42 +43,39 @@ export function getIRSCSV(pathObj) {
   return fetch(pathObj)
 }
 
-export function postVerify(submission, type, verified) {
+export function postVerify(type, verified) {
   return fetch({
-    submission: submission,
     suffix: `/edits/${type}`,
     method: 'POST',
     body: { verified: verified }
   })
 }
 
-export function getIRS(submission) {
-  return fetch({ submission: submission, suffix: '/irs' })
+export function getIRS() {
+  return fetch({ suffix: '/irs' })
 }
 
-export function getSummary(submission) {
-  return fetch({ submission: submission, suffix: '/summary' })
+export function getSummary() {
+  return fetch({ suffix: '/summary' })
 }
 
-export function getSignature(submission) {
-  return fetch({ submission: submission, suffix: '/sign' })
+export function getSignature() {
+  return fetch({ suffix: '/sign' })
 }
 
-export function getParseErrors(submission) {
-  return fetch({ submission: submission, suffix: '/parseErrors' })
+export function getParseErrors() {
+  return fetch({ suffix: '/parseErrors' })
 }
 
-export function postUpload(submission, body) {
+export function postUpload(body) {
   return fetch({
-    submission: submission,
     method: 'POST',
     body: body
   })
 }
 
-export function postSignature(submission, signed) {
+export function postSignature(signed) {
   return fetch({
-    submission: submission,
     suffix: '/sign',
     method: 'POST',
     body: { signed: signed }

--- a/src/api/api.test.js
+++ b/src/api/api.test.js
@@ -19,9 +19,8 @@ describe('api', () => {
   })
 
   it('posts upload', () => {
-    api.postUpload('1', {})
+    api.postUpload({})
     expect(mockedFetch.mock.calls[2][0]).toEqual({
-      submission: '1',
       method: 'POST',
       body: {}
     })
@@ -52,40 +51,32 @@ describe('api', () => {
   it('gets edits', () => {
     api.getEdits({})
     expect(mockedFetch.mock.calls[6][0]).toEqual({ suffix: '/edits' })
-
-    api.getEdits({ suffix: '1' })
-    expect(mockedFetch.mock.calls[7][0]).toEqual({ suffix: '1' })
   })
 
   it('gets edit', () => {
     api.getEdit({ edit: '1' })
-    expect(mockedFetch.mock.calls[8][0]).toEqual({
-      edit: '1',
+    expect(mockedFetch.mock.calls[7][0]).toEqual({
       suffix: '/edits/1'
     })
-
-    api.getEdit({ suffix: '1' })
-    expect(mockedFetch.mock.calls[9][0]).toEqual({ suffix: '1' })
   })
 
   it('gets csv', () => {
     api.getCSV({})
-    expect(mockedFetch.mock.calls[10][0]).toEqual({
+    expect(mockedFetch.mock.calls[8][0]).toEqual({
       params: { format: 'csv' },
       suffix: '/edits/csv'
     })
 
     api.getCSV({ suffix: '1' })
-    expect(mockedFetch.mock.calls[11][0]).toEqual({
+    expect(mockedFetch.mock.calls[9][0]).toEqual({
       params: { format: 'csv' },
       suffix: '1'
     })
   })
 
   it('posts verify', () => {
-    api.postVerify('1', '2', '3')
-    expect(mockedFetch.mock.calls[12][0]).toEqual({
-      submission: '1',
+    api.postVerify('2', '3')
+    expect(mockedFetch.mock.calls[10][0]).toEqual({
       suffix: '/edits/2',
       method: 'POST',
       body: { verified: '3' }
@@ -93,41 +84,49 @@ describe('api', () => {
   })
 
   it('gets irs', () => {
-    api.getIRS('1')
-    expect(mockedFetch.mock.calls[13][0]).toEqual({
-      submission: '1',
+    api.getIRS()
+    expect(mockedFetch.mock.calls[11][0]).toEqual({
       suffix: '/irs'
     })
   })
 
+  it('gets irscsv', () => {
+    api.getIRSCSV({})
+    expect(mockedFetch.mock.calls[12][0]).toEqual({
+      params: { format: 'csv' },
+      suffix: '/irs/csv'
+    })
+    api.getIRSCSV({ suffix: 'a' })
+    expect(mockedFetch.mock.calls[13][0]).toEqual({
+      params: { format: 'csv' },
+      suffix: 'a'
+    })
+  })
+
   it('gets summary', () => {
-    api.getSummary('1')
+    api.getSummary()
     expect(mockedFetch.mock.calls[14][0]).toEqual({
-      submission: '1',
       suffix: '/summary'
     })
   })
 
   it('gets signature', () => {
-    api.getSignature('1')
+    api.getSignature()
     expect(mockedFetch.mock.calls[15][0]).toEqual({
-      submission: '1',
       suffix: '/sign'
     })
   })
 
   it('gets parse errors', () => {
-    api.getParseErrors('1')
+    api.getParseErrors()
     expect(mockedFetch.mock.calls[16][0]).toEqual({
-      submission: '1',
       suffix: '/parseErrors'
     })
   })
 
   it('posts signature', () => {
-    api.postSignature('1', '2')
+    api.postSignature('2')
     expect(mockedFetch.mock.calls[17][0]).toEqual({
-      submission: '1',
       suffix: '/sign',
       method: 'POST',
       body: { signed: '2' }


### PR DESCRIPTION
Depends on #1039
Removes submission keys from api and also removes submission setter/getter which was secretly nestled in the actions