### PR TITLE
let the login button be the primary action

### DIFF
--- a/src/home/index.jsx
+++ b/src/home/index.jsx
@@ -25,15 +25,16 @@ const Home = () => {
               Log in
             </button>
             <span className="usa-text-small">or</span>
-            <button
-              className="register-link"
+            <a
+              href="#"
+              className="register-link usa-text-small"
               onClick={e => {
                 e.preventDefault()
                 register(window.HMDA_ENV.APP_SUFFIX + 'institutions')
               }}
             >
               Create an account
-            </button>
+            </a>
             <p className="usa-text-small">
               Every user is required to register online for login credentials
               and establish an account prior to accessing the HMDA Platform.


### PR DESCRIPTION
Closes #1070 

### Screenshot ("create an account" is now a link vs a button)
![create-account](https://user-images.githubusercontent.com/2932572/43211539-bd11cbb4-8fff-11e8-8bc1-aec7d9c929ee.png)
