### PR TITLE
cleaning out authentication

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,22 +1,18 @@
 import React, { Component } from 'react'
 import { connect } from 'react-redux'
-import { getUserManager, signinRedirect } from './utils/redirect.js'
 import ConfirmationModal from './modals/confirmationModal/container.jsx'
-import LoggedOutModal from './modals/loggedOutModal/container.jsx'
-import * as AccessToken from './api/AccessToken.js'
 import Header from './common/Header.jsx'
 import Footer from './common/Footer.jsx'
 import BrowserBlocker from './common/BrowserBlocker.jsx'
 import Loading from './common/Loading.jsx'
 import makeAction from './actions/makeAction.js'
 import { error } from './utils/log.js'
-import { USER_LOADING, USER_EXPIRED, USER_FOUND } from './constants'
 import browser from 'detect-browser'
 
 export class AppContainer extends Component {
   _renderAppContents(props) {
     if (this._isOldBrowser()) return <BrowserBlocker />
-    if (props.redirecting || (!props.oidc && !this._isUnprotected(props)))
+    if (props.redirecting || !props.oidc)
       return <Loading className="floatingIcon" />
     return props.children
   }
@@ -26,49 +22,7 @@ export class AppContainer extends Component {
   }
 
   _isHome(props) {
-    return props.location.pathname === window.HMDA_ENV.APP_SUFFIX
-  }
-
-  _isOidc(props) {
-    return (
-      props.location.pathname === window.HMDA_ENV.APP_SUFFIX + 'oidc-callback'
-    )
-  }
-
-  _isUnprotected(props) {
-    return this._isOidc(props) || this._isHome(props)
-  }
-
-  _handleUser(user) {
-    if (!user || user.expired) this.props.dispatch(makeAction(USER_EXPIRED))
-    else {
-      AccessToken.set(user.access_token)
-      this.props.dispatch(makeAction(USER_FOUND, user))
-    }
-  }
-
-  _userError(err) {
-    error('Error loading user.', err)
-  }
-
-  componentWillMount() {
-    if (!this.props.oidc || this.props.oidc.expired) {
-      this.props.dispatch(makeAction(USER_LOADING))
-      getUserManager()
-        .getUser()
-        .then(this._handleUser.bind(this))
-        .catch(this._userError)
-    } else {
-      AccessToken.set(this.props.oidc.access_token)
-    }
-  }
-
-  componentWillUpdate(props) {
-    if (props.oidc || props.isFetching) return
-
-    if (this._isUnprotected(props)) return
-
-    signinRedirect()
+    return props.location.pathname === '/filing'
   }
 
   render() {
@@ -77,10 +31,7 @@ export class AppContainer extends Component {
         <a className="usa-skipnav" href="#main-content">
           Skip to main content
         </a>
-        <Header
-          pathname={this.props.location.pathname}
-          user={this.props.oidc}
-        />
+        <Header pathname={this.props.location.pathname} />
         {this.props.userError && !this.props.redirecting ? (
           <LoggedOutModal />
         ) : (

--- a/src/common/Header.jsx
+++ b/src/common/Header.jsx
@@ -18,7 +18,7 @@ export const makeNav = (props, page) => {
   let userHeader = (
     <ul className="usa-nav-primary">
       <li>
-        <Link to={window.HMDA_ENV.APP_SUFFIX} className="usa-nav-link">
+        <Link to={'/filing'} className="usa-nav-link">
           Filing Home
         </Link>
       </li>
@@ -53,7 +53,7 @@ const Header = props => {
           <em className="usa-logo-text">
             <Link
               className="usa-nav-link"
-              to={window.HMDA_ENV.APP_SUFFIX}
+              to="/filing"
               title="Home"
               aria-label="Home"
             >
@@ -69,7 +69,7 @@ const Header = props => {
 }
 
 Header.propTypes = {
-  user: PropTypes.object,
+  //user: PropTypes.object,
   pathname: PropTypes.string
 }
 


### PR DESCRIPTION
The start of cleaning out the current authentication for v2. I wanted to start small PRs to walk through this.

Do you see anything, or know of anything, that I'm missing? I haven't deleted any of the files, I've only commented out or removed code at this point.

This will definitely break the build, but it's going to the `v2` branch and the next steps will get it cleaned up and working again.

### Rough next steps

1. Bring in CRA.
    1. Will submit a PR with only dependecy updates
1. Make sure it can build, without authentication, and at least point to the `v2` API using the proxy feature of CRA and relative paths.
1. Clean up styling (`scss -> css`).
1. Final clean up.
1. Bring back auth.