### PR TITLE
Syntactical and validity

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "detect-browser": "1.7.0",
     "file-saver": "1.3.3",
-    "normalize.css": "^8.0.0",
+    "normalize.css": "8.0.0",
     "react": "16.4.2",
     "react-app-polyfill": "0.1.3",
     "react-dom": "16.4.2",

--- a/src/api/api.js
+++ b/src/api/api.js
@@ -180,7 +180,96 @@ export function getLatestSubmission() {
 }
 
 export function getEdits() {
-  return fetch({ suffix: '/edits' })
+  // return fetch({ suffix: '/edits' })
+
+  return new Promise(resolve => {
+    resolve({
+      quality: {
+        verified: false,
+        edits: [
+          {
+            edit: 'Q030',
+            description:
+              'If action taken type = 1, 2, 3, 4, 5, or 6; and if the HMDA respondent is required to report MSA/MD, state, county, census tract, then MSA/MD, state, county, census tract should equal a valid combination and not NA.'
+          },
+          {
+            edit: 'Q130',
+            description:
+              'The number of loan/application records received in this transmission file per respondent does not = the total number of loan/application records reported in this respondent’s transmission or the total number of loan/application records in this submission is missing from the transmittal sheet.'
+          }
+        ]
+      },
+      macro: {
+        verified: false,
+        edits: [
+          {
+            edit: 'Q008',
+            description:
+              'If action taken type = 4, then the total number of these loans should be ≤ 30% of the total number of loan applications.'
+          },
+          {
+            edit: 'Q010',
+            description:
+              'The number of loan applications that report action taken type = 1 should be ≥ 20% of the total number of loan applications where action taken type = 1-6.'
+          },
+          {
+            edit: 'Q023',
+            description:
+              'The number of loan applications that report MSA/MD = NA should be ≤ 30% of the total number of loan applications.'
+          }
+        ]
+      },
+      status: {
+        code: 8,
+        message: 'Your data has edits that need to be reviewed.',
+        description:
+          'Your file has been uploaded, but the filing process may not proceed until edits are verified or the file is corrected and re-uploaded.'
+      },
+      validity: {
+        edits: [
+          {
+            edit: 'V125',
+            description:
+              'Tax ID number must be in NN-NNNNNNN format and not = (99-9999999 or 00-0000000 or blank).'
+          },
+          { edit: 'V550', description: 'Lien status must = 1, 2, 3, or 4.' },
+          {
+            edit: 'V555',
+            description:
+              'If loan purpose = 1 or 3, then lien status must = 1, 2, or 4.'
+          },
+          {
+            edit: 'V560',
+            description:
+              'If action taken type = 1-5, 7 or 8, then lien status must = 1, 2, or 3.'
+          }
+        ]
+      },
+      syntactical: {
+        edits: [
+          {
+            edit: 'S010',
+            description:
+              'The first record identifier in the file must = 1 (TS). The second and all subsequent record identifiers must = 2 (LAR).'
+          },
+          {
+            edit: 'S020',
+            description:
+              'Agency code must = 1, 2, 3, 5, 7, 9. The agency that submits the data must be the same as the reported agency code.'
+          },
+          {
+            edit: 'S025',
+            description:
+              'Control number must = a valid respondent identifier/agency code combination for date processed. Please note the respondent-id should not include any leading zeros or a dash.'
+          },
+          {
+            edit: 'S100',
+            description: 'Activity year must = year being processed (= 2017).'
+          }
+        ]
+      }
+    })
+  })
 }
 
 export function getEdit(pathObj) {

--- a/src/api/api.js
+++ b/src/api/api.js
@@ -168,10 +168,10 @@ export function getLatestSubmission() {
       id: { institutionId: '0', period: '2017', sequenceNumber: 289 },
       receipt: '0-2017-289-1540304400322',
       status: {
-        code: 5,
-        message: 'Your data has formatting errors.',
+        code: 8,
+        message: 'Your data has edits that need to be reviewed.',
         description:
-          'Review these errors and update your file. Then, upload the corrected file.'
+          'Your file has been uploaded, but the filing process may not proceed until edits are verified or the file is corrected and re-uploaded.'
       },
       end: 1540304400322,
       start: 1540303997250

--- a/src/api/api.js
+++ b/src/api/api.js
@@ -273,9 +273,9 @@ export function getEdits() {
 }
 
 export function getEdit(pathObj) {
-  // return fetch({ suffix: `/edits/${pathObj.edit}` })
+  return fetch({ suffix: `/edits/${pathObj.edit}` })
 
-  return new Promise(resolve => {
+  /*return new Promise(resolve => {
     resolve({
       count: 1,
       total: 1,
@@ -295,7 +295,7 @@ export function getEdit(pathObj) {
         href: '/institutions/0/filings/2017/submissions/291/edits/S100{rel}'
       }
     })
-  })
+  })*/
 }
 
 export function getCSV(pathObj) {

--- a/src/api/api.js
+++ b/src/api/api.js
@@ -273,7 +273,29 @@ export function getEdits() {
 }
 
 export function getEdit(pathObj) {
-  return fetch({ suffix: `/edits/${pathObj.edit}` })
+  // return fetch({ suffix: `/edits/${pathObj.edit}` })
+
+  return new Promise(resolve => {
+    resolve({
+      count: 1,
+      total: 1,
+      edit: 'S010',
+      rows: [
+        {
+          row: { rowId: 'Transmittal Sheet' },
+          fields: { 'Activity Year': 2013 }
+        }
+      ],
+      _links: {
+        self: '?page=1',
+        prev: '?page=1',
+        last: '?page=1',
+        next: '?page=1',
+        first: '?page=1',
+        href: '/institutions/0/filings/2017/submissions/291/edits/S100{rel}'
+      }
+    })
+  })
 }
 
 export function getCSV(pathObj) {

--- a/src/common/Alert.css
+++ b/src/common/Alert.css
@@ -39,7 +39,6 @@
 }
 .alert-slim .alert-text:only-child {
   margin-bottom: 0.5rem;
-  padding-top: 0.5rem;
 }
 
 .alert-icon {

--- a/src/common/edit.json
+++ b/src/common/edit.json
@@ -1,0 +1,19 @@
+{
+  "count": 1,
+  "total": 1,
+  "edit": "S100",
+  "rows": [
+    {
+      "row": { "rowId": "Transmittal Sheet" },
+      "fields": { "Activity Year": 2013 }
+    }
+  ],
+  "_links": {
+    "self": "?page=1",
+    "prev": "?page=1",
+    "last": "?page=1",
+    "next": "?page=1",
+    "first": "?page=1",
+    "href": "/institutions/0/filings/2017/submissions/291/edits/S100{rel}"
+  }
+}

--- a/src/refileWarning/index.jsx
+++ b/src/refileWarning/index.jsx
@@ -16,7 +16,7 @@ export const getText = props => {
   let periodAfter = false
   let reviewAndDownload = (
     <div>
-      Please review the edits or <CSVDownload />
+      Please review the edits or <CSVDownload inline={true} />
     </div>
   )
 

--- a/src/submission/edits/Header.css
+++ b/src/submission/edits/Header.css
@@ -1,8 +1,13 @@
+.EditsHeaderDescription {
+  max-width: 77rem;
+}
 .EditsHeaderDescription h2 {
+  font-size: 3rem;
   margin-top: 0;
 }
-.EditsHeaderDescription p.usa-font-lead {
+.EditsHeaderDescription p.font-lead {
   color: #323a45;
+  font-size: 2rem;
   margin-top: 0.5em;
   margin-bottom: 0;
 }

--- a/src/submission/edits/Header.jsx
+++ b/src/submission/edits/Header.jsx
@@ -46,7 +46,7 @@ const EditsHeaderDescription = ({ type, count, fetched, suppressCount }) => {
         {countEl}
         {!fetched && !suppressCount ? <Loading /> : null}
       </h2>
-      <p className="usa-font-lead">{desc}</p>
+      <p className="font-lead">{desc}</p>
     </header>
   )
 }

--- a/src/submission/edits/SuppressionAlert.jsx
+++ b/src/submission/edits/SuppressionAlert.jsx
@@ -7,7 +7,7 @@ export const SuppressionAlert = props => {
     <Alert type="warning">
       <p>
         Sorry, we can't display tables of rows for each of your edits. To review
-        the affected rows, <CSVDownload />
+        the affected rows, <CSVDownload inline={true} />
       </p>
     </Alert>
   )

--- a/src/submission/edits/TableWrapper.jsx
+++ b/src/submission/edits/TableWrapper.jsx
@@ -69,7 +69,14 @@ export const renderTablesOrSuccess = (props, edits, type) => {
   }
 
   return edits.map((edit, i) => {
-    return <EditsTable edit={edit} type={type} suppressEdits={false} key={i} />
+    return (
+      <EditsTable
+        edit={edit}
+        type={type}
+        suppressEdits={props.suppressEdits}
+        key={i}
+      />
+    )
   })
 }
 

--- a/src/submission/edits/TableWrapper.jsx
+++ b/src/submission/edits/TableWrapper.jsx
@@ -61,21 +61,15 @@ export const renderTablesOrSuccess = (props, edits, type) => {
     return (
       <Alert type="success">
         <p>
-          Your data did not trigger any {type} edits{verificationMsg}
+          Your data did not trigger any {type} edits
+          {verificationMsg}
         </p>
       </Alert>
     )
   }
 
   return edits.map((edit, i) => {
-    return (
-      <EditsTable
-        edit={edit}
-        type={type}
-        suppressEdits={props.suppressEdits}
-        key={i}
-      />
-    )
+    return <EditsTable edit={edit} type={type} suppressEdits={false} key={i} />
   })
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6345,7 +6345,7 @@ normalize-url@^3.0.0:
   resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-3.3.0.tgz#b2e1c4dc4f7c6d57743df733a4f5978d18650559"
   integrity sha512-U+JJi7duF1o+u2pynbp2zXDW2/PADgC30f0GsHZtRh+HOcXHnw137TrNlyxxRvWW5fjKd3bcLHPxofWuCjaeZg==
 
-normalize.css@^8.0.0:
+normalize.css@8.0.0:
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/normalize.css/-/normalize.css-8.0.0.tgz#14ac5e461612538a4ce9be90a7da23f86e718493"
   integrity sha512-iXcbM3NWr0XkNyfiSBsoPezi+0V92P9nj84yVV1/UZxRUrGczgX/X91KMAGM0omWLY2+2Q1gKD/XRn4gQRDB2A==


### PR DESCRIPTION
### Depends on #1096 

As is this PR will render the __suppressed__ edits. 

![edit-suppressed](https://user-images.githubusercontent.com/2932572/47668164-1933fd80-db7e-11e8-899e-ee1bc184f2b6.png)

You can see the "normal" edits view by:

1. commenting out the [`return fetch({ suffix: '/edits/${pathObj.edit}' })`](https://github.com/cfpb/hmda-platform-ui/pull/1097/files#diff-46908a2fc227e9faf10d6c95ac926be9R276) and __un__commenting the mocked `getEdit` API response in `api.js, 
1. [in `TableWrapper`, set `suppressEdits` to `false`](https://github.com/cfpb/hmda-platform-ui/pull/1097/files#diff-83651818d873e276120f7b834457f1f8R76).

You will see the loading icon for all the edits except for `S010`. This is ok for now because we just want to be sure the edits are rendering correctly and this does that. Once we're completely hooked up to the back-end the other edits will render correctly.

![edits](https://user-images.githubusercontent.com/2932572/47666554-35ce3680-db7a-11e8-8a6f-821eb729af8c.png)

