### PR TITLE
Quality edits

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -63,8 +63,18 @@ hr {
   border-top: 1px solid #aeb0b5;
 }
 
+.font-lead {
+  font-size: 2rem;
+}
+
 .text-small {
   font-size: 1.3rem;
+}
+
+.unstyled-list {
+  list-style-type: none;
+  margin: 0;
+  padding-left: 0;
 }
 
 button,

--- a/src/common/Footer.css
+++ b/src/common/Footer.css
@@ -40,11 +40,6 @@
 .Footer .grid .item:last-child {
   margin-right: 0;
 }
-.Footer .unstyled-list {
-  list-style-type: none;
-  margin: 0;
-  padding-left: 0;
-}
 
 .return-to-top {
   margin-bottom: 1em;

--- a/src/submission/edits/Header.css
+++ b/src/submission/edits/Header.css
@@ -7,7 +7,6 @@
 }
 .EditsHeaderDescription p.font-lead {
   color: #323a45;
-  font-size: 2rem;
   margin-top: 0.5em;
   margin-bottom: 0;
 }

--- a/src/submission/edits/Verifier.css
+++ b/src/submission/edits/Verifier.css
@@ -12,25 +12,33 @@
 .Verifier .animated-alert {
   animation: 0.2s ease-out 0s 1 VerifierAlertAnimation;
 }
+
 .Verifier hr {
   margin-bottom: 2em;
 }
 .Verifier h2 {
   margin-top: 0;
 }
+
 .Verifier .LoadingIconWrapper {
   position: absolute;
 }
-
 .Verifier .LoadingIcon {
   left: -38px;
   top: 27px;
 }
 
-.Verifier .usa-font-lead {
+.Verifier li {
+  margin-top: 1em;
+}
+
+.Verifier input[type='checkbox'] {
+  margin-right: 1em;
+}
+.Verifier .font-lead {
   margin-top: 0.5em;
   margin-bottom: 0;
 }
-.Verifier .usa-alert-text span {
+.Verifier .alert-text span {
   text-transform: capitalize;
 }

--- a/src/submission/edits/Verifier.jsx
+++ b/src/submission/edits/Verifier.jsx
@@ -41,11 +41,11 @@ class Verifier extends Component {
       <section className="Verifier">
         <hr />
         <h2>Verify {props.type} edits</h2>
-        <p className="usa-font-lead">
+        <p className="font-lead">
           In order to continue you must verify all {props.type} edits.
         </p>
         {props.isFetching ? <Loading /> : null}
-        <ul className="usa-unstyled-list">
+        <ul className="unstyled-list">
           <li>
             <input
               id={`${props.type}Verifier`}

--- a/src/submission/router.jsx
+++ b/src/submission/router.jsx
@@ -80,9 +80,10 @@ export class SubmissionRouter extends Component {
     const code = status.code
     const types = this.props.types
 
-    const synvalExist = !!(
+    /*const synvalExist = !!(
       types.syntactical.edits.length + types.validity.edits.length
-    )
+    )*/
+    const synvalExist = false
     const qualityExist = !!types.quality.edits.length && !types.quality.verified
 
     if (code < VALIDATED_WITH_ERRORS) return 'upload'


### PR DESCRIPTION
### Depends on #1097 

### 🚨 NOTE: this actually takes care of macro too.

Gets the quality edits up to date. You'll notice the syntactical/validity error message still, but it's ok for now. We need to re-work some logic around [the status code updates anyway](https://github.com/cfpb/hmda-platform/blob/9654c2b5810a0755bf84f064035c34897ecb5c7f/docs/v2/api/submission-status-codes.md). ([Issue here](https://github.com/cfpb/hmda-platform-ui/issues/1024).)

![quality](https://user-images.githubusercontent.com/2932572/47675111-6bc9e580-db8f-11e8-850a-0ad905ddfdbc.png)
