### PR TITLE
Poll updated for new codes

### DIFF
--- a/src/actions/pollForProgress.js
+++ b/src/actions/pollForProgress.js
@@ -58,7 +58,7 @@ export default function pollForProgress() {
           code !== SYNTACTICAL_VALIDITY_EDITS &&
           code !== QUALITY_EDITS &&
           code !== MACRO_EDITS &&
-          code !== VALIDATED
+          code < VALIDATED
         ) {
           setTimeout(poller.bind(null, dispatch), getTimeoutDuration())
         } else if (

--- a/src/actions/pollForProgress.js
+++ b/src/actions/pollForProgress.js
@@ -7,6 +7,9 @@ import { error } from '../utils/log.js'
 import {
   PARSED_WITH_ERRORS,
   VALIDATING,
+  SYNTACTICAL_VALIDITY_EDITS,
+  QUALITY_EDITS,
+  MACRO_EDITS,
   VALIDATED
 } from '../constants/statusCodes.js'
 
@@ -48,16 +51,20 @@ export default function pollForProgress() {
       })
       .then(json => {
         if (!json) return
+        const { code } = json.status
         if (
           // continue polling until we reach a status that isn't processing
-          json.status.code <= VALIDATING &&
-          json.status.code !== PARSED_WITH_ERRORS
+          code !== PARSED_WITH_ERRORS &&
+          code !== SYNTACTICAL_VALIDITY_EDITS &&
+          code !== QUALITY_EDITS &&
+          code !== MACRO_EDITS &&
+          code !== VALIDATED
         ) {
           setTimeout(poller.bind(null, dispatch), getTimeoutDuration())
         } else if (
           // we don't need edits if it parsed with errors
-          json.status.code > VALIDATING &&
-          json.status.code < VALIDATED
+          code > VALIDATING &&
+          code < VALIDATED
         ) {
           return dispatch(fetchEdits())
         }

--- a/src/submission/upload/index.jsx
+++ b/src/submission/upload/index.jsx
@@ -6,8 +6,11 @@ import Dropzone from 'react-dropzone'
 import DropzoneContent from './DropzoneContent.jsx'
 import {
   UPLOADING,
-  VALIDATING,
-  PARSED_WITH_ERRORS
+  PARSED_WITH_ERRORS,
+  SYNTACTICAL_VALIDITY_EDITS,
+  QUALITY_EDITS,
+  MACRO_EDITS,
+  VALIDATED
 } from '../../constants/statusCodes.js'
 
 import './UploadForm.css'
@@ -25,20 +28,14 @@ export default class Upload extends Component {
 
   componentDidMount() {
     const { code, pollSubmission } = this.props
-    /* TODO
-    // we may need to update this to something like
-    // we'll have to see what a clean file upload does
     if (
       code >= UPLOADING &&
-      code <= VALIDATED &&
+      code < VALIDATED &&
       code !== PARSED_WITH_ERRORS &&
       code !== SYNTACTICAL_VALIDITY_EDITS &&
       code !== QUALITY_EDITS &&
       code !== MACRO_EDITS
     )
-      pollSubmission()
-    */
-    if (code >= UPLOADING && code <= VALIDATING && code !== PARSED_WITH_ERRORS)
       pollSubmission()
   }
 


### PR DESCRIPTION
Closes #1129 (which is mostly a backend change, but this is tangentially related).

The poll will now continue until we get to a terminal state (which is no longer necessarily just a code greater than validating). Also, `pollSubmission` now gets kicked off under these same correct conditions.