### PR TITLE
Generic LEI info message

### DIFF
--- a/src/common/Alert.css
+++ b/src/common/Alert.css
@@ -57,6 +57,10 @@
   margin-bottom: 0;
 }
 
+.alert-heading.heading-small {
+  font-size: 1em;
+}
+
 .alert-text {
   font-family: SourceSansPro;
   margin-bottom: 0;

--- a/src/common/Alert.jsx
+++ b/src/common/Alert.jsx
@@ -3,7 +3,13 @@ import PropTypes from 'prop-types'
 
 import './Alert.css'
 
-const Alert = ({ type = 'info', heading, imageText, children }) => {
+const Alert = ({
+  type = 'info',
+  heading,
+  headingType='normal',
+  imageText,
+  children
+}) => {
   if (!children) return null
   let alertText
   let alertClass = ''
@@ -27,12 +33,15 @@ const Alert = ({ type = 'info', heading, imageText, children }) => {
     }
   }
 
+  let headingClass = 'alert-heading'
+  if(headingType === 'small') headingClass += ' heading-small'
+
   return (
     <div className={`alert alert-${type}`}>
       {/*<div className={`AlertImage ${alertClass}`}>{alertText}</div>*/}
       <div className="alert-body">
-        {heading ? <h3 className="alert-heading">{heading}</h3> : null}
-        {React.cloneElement(children, { className: 'alert-text' })}
+        {heading ? <h3 className={headingClass}>{heading}</h3> : null}
+        {React.cloneElement(children, { className: children.props.className || 'alert-text' })}
       </div>
     </div>
   )
@@ -40,7 +49,8 @@ const Alert = ({ type = 'info', heading, imageText, children }) => {
 
 Alert.propTypes = {
   type: PropTypes.oneOf(['info', 'success', 'warning', 'error']),
-  heading: PropTypes.string
+  heading: PropTypes.string,
+  headingType: PropTypes.string
 }
 
 export default Alert

--- a/src/institutions/index.jsx
+++ b/src/institutions/index.jsx
@@ -83,12 +83,19 @@ export default class Institutions extends Component {
 
           {_whatToRender(this.props)}
 
-          {this.props.institutions.fetched ? (
-            <p className="multi-message">
-              If you are planning to file on behalf of more than one financial
-              institution, contact{' '}
-              <a href="mailto:hmdahelp@cfpb.gov">hmdahelp@cfpb.gov</a>.
-            </p>
+          {this.props.institutions.fetched &&
+           Object.keys(this.props.institutions.institutions).length !== 0 ? (
+             <Alert heading="Missing an institution?" type="info" headingType="small">
+               <p className="text-small">
+                 In order to access the HMDA Platform, each of your institutions must{' '}
+                 have a Legal Entity Identifier (LEI). In order to provide your{' '}
+                 institution&#39;s LEI, please access <a href="https://hmdahelp.consumerfinance.gov/accounthelp/">this form</a> and enter the{' '}
+                 necessary information, including your HMDA Platform account{' '}
+                 email address in the &#34;Additional comments&#34; text box. We will{' '}
+                 apply the update to your account, please check back 2 business{' '}
+                 days after submitting your information.
+               </p>
+             </Alert>
           ) : null}
         </div>
       </main>


### PR DESCRIPTION
Closes #1114 

At least for beta, we decided that including a slightly reworded version of the no-lei alert makes sense to show for all users. Then we don't have to provide an institutions attributes in keycloak or introduce a dependency on the 2017 filing platform from the 2018 app.

I tweaked the Alert module a bit to provide for a more understated alert since otherwise it takes up quite a bit of screen real estate.

Also, it should be noted that this replaces the former "if you're filing for more than one institution" message, since (if my assumption is correct), that won't need special intervention outside of just filling out the hmda-help form multiple times.