### PR TITLE
we will have to roll this change back …

### DIFF
--- a/src/reducers/edits.js
+++ b/src/reducers/edits.js
@@ -15,7 +15,7 @@ import {
 
 const defaultEdits = {
   isFetching: false,
-  suppressEdits: false,
+  suppressEdits: true,
   fetched: false,
   types: {
     syntactical: { edits: [] },


### PR DESCRIPTION
but since the API responses are not complete we can suppress the edit details for now.