### PR TITLE
updates to have the root of the v2 filing UI be /filing/2018

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,6 @@ RUN yarn build
 FROM nginx:1.15.1-alpine
 RUN rm -rf /etc/nginx/conf.d
 COPY nginx /etc/nginx
-COPY --from=build-stage /usr/src/app/build /usr/share/nginx/html/filing
+COPY --from=build-stage /usr/src/app/build /usr/share/nginx/html/filing/2018
 EXPOSE 80
 CMD ["nginx", "-g", "daemon off;"]

--- a/kubernetes/hmda-platform-ui/templates/service.yaml
+++ b/kubernetes/hmda-platform-ui/templates/service.yaml
@@ -30,8 +30,8 @@ metadata:
       apiVersion: ambassador/v0
       kind: Mapping
       name: platform_ui_mapping
-      prefix: /filing/
-      rewrite: /filing/
+      prefix: /filing/2018/
+      rewrite: /filing/2018/
       service: {{ include "hmda-platform-ui.fullname" . }}:{{ .Values.service.port }}
 spec:
   type: {{ .Values.ambassador.service.type }}

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -69,11 +69,11 @@ http {
       try_files $uri =404;
     }
 
-    location /filing {
+    location /filing/2018 {
       limit_except GET {
         deny all;
       }
-      try_files '' /filing/index.html;
+      try_files '' /filing/2018/index.html;
     }
   }
 

--- a/package.json
+++ b/package.json
@@ -53,5 +53,5 @@
   "devDependencies": {
     "redux-devtools-extension": "2.13.2"
   },
-  "homepage": "/filing"
+  "homepage": "/filing/2018"
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -24,7 +24,8 @@ export class AppContainer extends Component {
         if (this.props.redirecting) this.props.dispatch(isRedirecting(false))
         else this.forceUpdate()
       } else {
-        if (!this._isHome(this.props)) keycloak.login(this.props.location.pathname)
+        if (!this._isHome(this.props))
+          keycloak.login(this.props.location.pathname)
       }
     })
   }
@@ -49,7 +50,7 @@ export class AppContainer extends Component {
   }
 
   _isHome(props) {
-    return !!props.location.pathname.match(/^\/filing\/?$/)
+    return !!props.location.pathname.match(/^\/filing\/2018\/$/)
   }
 
   render() {

--- a/src/common/Footer.jsx
+++ b/src/common/Footer.jsx
@@ -5,8 +5,8 @@ import logo from '../images/ffiec-logo.svg'
 import { getKeycloak } from '../utils/keycloak.js'
 
 export const getLink = () => {
-  if (getKeycloak().authenticated) return '/filing/institutions'
-  return '/filing/'
+  if (getKeycloak().authenticated) return '/filing/2018/institutions'
+  return '/filing/2018/'
 }
 
 const Footer = () => {

--- a/src/common/Header.jsx
+++ b/src/common/Header.jsx
@@ -18,8 +18,8 @@ export const logOutHandler = e => {
 }
 
 export const getLink = () => {
-  if(getKeycloak().authenticated) return '/filing/institutions'
-  return '/filing/'
+  if (getKeycloak().authenticated) return '/filing/2018/institutions'
+  return '/filing/2018/'
 }
 
 export const makeNav = (props, page) => {

--- a/src/index.js
+++ b/src/index.js
@@ -66,18 +66,21 @@ history.listen(location => {
 render(
   <Provider store={store}>
     <Router history={history} render={applyRouterMiddleware(useScroll())}>
-      <Route path={'/filing'} component={AppContainer}>
+      <Route path={'/filing/2018/'} component={AppContainer}>
         <IndexRoute component={HomeContainer} />
-        <Route path={'/filing/institutions'} component={InstitutionContainer} />
         <Route
-          path={'/filing/:institution/:filing'}
+          path={'/filing/2018/institutions'}
+          component={InstitutionContainer}
+        />
+        <Route
+          path={'/filing/2018/:institution/:filing'}
           component={SubmissionRouter}
         />
         <Route
-          path={'/filing/:institution/:filing/*'}
+          path={'/filing/2018/:institution/:filing/*'}
           component={SubmissionRouter}
         />
-        <Route path={'/filing/*'} component={SubmissionRouter} />
+        <Route path={'/filing/2018/*'} component={SubmissionRouter} />
       </Route>
     </Router>
   </Provider>,

--- a/src/institutions/ViewButton.jsx
+++ b/src/institutions/ViewButton.jsx
@@ -17,7 +17,7 @@ import './ViewButton.css'
 const InstitutionViewButton = ({ status, institution, filingPeriod }) => {
   const code = status ? status.code : CREATED
   let text
-  if(code === FAILED) {
+  if (code === FAILED) {
     return <RefileButton className="ViewButton" institution={institution} />
   } else if (code <= CREATED) {
     text = 'Upload your file'
@@ -38,7 +38,7 @@ const InstitutionViewButton = ({ status, institution, filingPeriod }) => {
   return (
     <Link
       className="ViewButton button"
-      to={`/filing/${institution.id}/${filingPeriod}`}
+      to={`/filing/2018/${institution.id}/${filingPeriod}`}
     >
       {text}
     </Link>

--- a/src/modals/confirmationModal/container.jsx
+++ b/src/modals/confirmationModal/container.jsx
@@ -44,9 +44,7 @@ export function mapDispatchToProps(dispatch) {
       })
     } else {
       return dispatch(fetchNewSubmission(id, period)).then(() => {
-        browserHistory.replace(
-          `/filing/${id}/${period}/upload`
-        )
+        browserHistory.replace(`/filing/2018/${id}/${period}/upload`)
       })
     }
   }
@@ -57,4 +55,7 @@ export function mapDispatchToProps(dispatch) {
   }
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(ConfirmationModal)
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(ConfirmationModal)

--- a/src/submission/router.jsx
+++ b/src/submission/router.jsx
@@ -40,7 +40,7 @@ export class SubmissionRouter extends Component {
     dispatch(updateFilingPeriod(params.filing))
 
     const size = localStorage.getItem(`HMDA_FILE_SIZE/${params.institution}`)
-//  if (size > 5e6) dispatch(suppressEdits())
+    //  if (size > 5e6) dispatch(suppressEdits())
 
     if (unmatchedId || !status || status.code === UNINITIALIZED) {
       return dispatch(fetchSubmission()).then(json => {
@@ -72,11 +72,13 @@ export class SubmissionRouter extends Component {
 
   replaceHistory(splat) {
     const { institution, filing } = this.props.params
-    return browserHistory.replace(`/filing/${institution}/${filing}/${splat}`)
+    return browserHistory.replace(
+      `/filing/2018/${institution}/${filing}/${splat}`
+    )
   }
 
   goToAppHome() {
-    return browserHistory.replace('/filing/')
+    return browserHistory.replace('/filing/2018/')
   }
 
   getLatestPage() {

--- a/src/utils/keycloak.js
+++ b/src/utils/keycloak.js
@@ -17,7 +17,7 @@ const getKeycloak = () => {
   return keycloak
 }
 
-const login = (path = '/filing/institutions')=> {
+const login = (path = '/filing/2018/institutions') => {
   if (!keycloak) return error('keycloak needs to be set on app initialization')
   dispatch(isRedirecting(true))
   keycloak.login({ redirectUri: location.origin + path })
@@ -27,7 +27,7 @@ const refresh = () => {
   const updateKeycloak = () => {
     setTimeout(() => {
       keycloak.updateToken().then(success => {
-        if(!success) return keycloak.login()
+        if (!success) return keycloak.login()
         AccessToken.set(keycloak.token)
         updateKeycloak()
       })
@@ -41,14 +41,22 @@ const register = () => {
 
   dispatch(isRedirecting(true))
   keycloak.login({
-    redirectUri: location.origin + '/filing/institutions',
+    redirectUri: location.origin + '/filing/2018/institutions',
     action: 'register'
   })
 }
 
 const logout = () => {
   if (!keycloak) return error('keycloak needs to be set on app initialization')
-  keycloak.logout({ redirectUri: location.origin + '/filing/' })
+  keycloak.logout({ redirectUri: location.origin + '/filing/2018/' })
 }
 
-export { setDispatch, getKeycloak, setKeycloak, register, login, logout, refresh }
+export {
+  setDispatch,
+  getKeycloak,
+  setKeycloak,
+  register,
+  login,
+  logout,
+  refresh
+}


### PR DESCRIPTION
Closes #1180 

This will serve the v2 UI from `/filing/2018`. This is to allow us to run both v1 (2017) and v2 (2018) together. We will be routing every all `/filing/2018` to v2 and all `/filing/` to v1.

This also includes updates to the `Dockerfile` and helm chart.