### PR TITLE
Update token

### DIFF
--- a/src/utils/keycloak.js
+++ b/src/utils/keycloak.js
@@ -25,19 +25,23 @@ const login = (path = '/filing/2018/institutions') => {
 
 const refresh = () => {
   const updateKeycloak = () => {
+    console.log('updateKeycloak')
+    console.log(+(keycloak.tokenParsed.exp + '000') - Date.now() - 10000)
     setTimeout(() => {
       keycloak
-        .updateToken(60)
+        .updateToken(20)
         .success(success => {
           if (success) {
+            console.log('success')
             AccessToken.set(keycloak.token)
           }
           updateKeycloak()
         })
         .error(error => {
+          console.log('error')
           return keycloak.login()
         })
-    }, +(keycloak.tokenParsed.exp + '000') - Date.now() - 50000)
+    }, +(keycloak.tokenParsed.exp + '000') - Date.now() - 10000)
   }
   updateKeycloak()
 }

--- a/src/utils/keycloak.js
+++ b/src/utils/keycloak.js
@@ -25,20 +25,16 @@ const login = (path = '/filing/2018/institutions') => {
 
 const refresh = () => {
   const updateKeycloak = () => {
-    console.log('updateKeycloak')
-    console.log(+(keycloak.tokenParsed.exp + '000') - Date.now() - 10000)
     setTimeout(() => {
       keycloak
         .updateToken(20)
         .success(success => {
           if (success) {
-            console.log('success')
             AccessToken.set(keycloak.token)
           }
           updateKeycloak()
         })
         .error(error => {
-          console.log('error')
           return keycloak.login()
         })
     }, +(keycloak.tokenParsed.exp + '000') - Date.now() - 10000)

--- a/src/utils/keycloak.js
+++ b/src/utils/keycloak.js
@@ -26,12 +26,18 @@ const login = (path = '/filing/2018/institutions') => {
 const refresh = () => {
   const updateKeycloak = () => {
     setTimeout(() => {
-      keycloak.updateToken().then(success => {
-        if (!success) return keycloak.login()
-        AccessToken.set(keycloak.token)
-        updateKeycloak()
-      })
-    }, +(keycloak.tokenParsed.exp + '000') - Date.now() - 10000)
+      keycloak
+        .updateToken(60)
+        .success(success => {
+          if (success) {
+            AccessToken.set(keycloak.token)
+          }
+          updateKeycloak()
+        })
+        .error(error => {
+          return keycloak.login()
+        })
+    }, +(keycloak.tokenParsed.exp + '000') - Date.now() - 50000)
   }
   updateKeycloak()
 }


### PR DESCRIPTION
Closes #1231 

There weren't ambassador errors because the call to update the token wasn't really failing, it just wasn't updating the token because the token hadn't expired ... or wasn't close enough to expiring.

This update

- uses the `error` to handle an actual error and only calls `login()` if the update errors,
- sets the [`updateToken(minValidity)`](https://www.keycloak.org/docs/3.0/securing_apps/topics/oidc/javascript-adapter.html#_updatetoken_minvalidity)(look for `minValidity`) to 60 seconds which means that if the token is due to expire within 60 seconds it will be refreshed,
- and makes the call to update the token a little more frequently to help ensure it doesn't expire.