### PR TITLE
K8s multi

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ FROM nginx:1.16-alpine
 ENV NGINX_USER=svc_nginx_hmda
 RUN rm -rf /etc/nginx/conf.d
 COPY nginx /etc/nginx
-COPY --from=build-stage /usr/src/app/build /usr/share/nginx/html/filing/
+COPY --from=build-stage /usr/src/app/build /usr/share/nginx/html/filing/build
 RUN adduser -S $NGINX_USER nginx && \
     addgroup -S $NGINX_USER && \
     addgroup $NGINX_USER $NGINX_USER && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ FROM nginx:1.16-alpine
 ENV NGINX_USER=svc_nginx_hmda
 RUN rm -rf /etc/nginx/conf.d
 COPY nginx /etc/nginx
-COPY --from=build-stage /usr/src/app/build /usr/share/nginx/html/filing/2018
+COPY --from=build-stage /usr/src/app/build /usr/share/nginx/html/filing/
 RUN adduser -S $NGINX_USER nginx && \
     addgroup -S $NGINX_USER && \
     addgroup $NGINX_USER $NGINX_USER && \

--- a/kubernetes/beta/hmda-platform-ui/templates/service.yaml
+++ b/kubernetes/beta/hmda-platform-ui/templates/service.yaml
@@ -31,8 +31,8 @@ metadata:
       kind: Mapping
       name: platform_ui_mapping
       ambassador_id: ambassador-beta-2
-      prefix: /filing/2018/
-      rewrite: /filing/2018/
+      prefix: /filing/
+      rewrite: ""
       service: {{ include "hmda-platform-ui.fullname" . }}:{{ .Values.service.port }}
 spec:
   type: {{ .Values.ambassador.service.type }}

--- a/kubernetes/hmda-platform-ui/templates/service.yaml
+++ b/kubernetes/hmda-platform-ui/templates/service.yaml
@@ -31,8 +31,8 @@ metadata:
       kind: Mapping
       name: platform_ui_mapping
       ambassador_id: ambassador-default-1
-      prefix: /filing/2018/
-      rewrite: /filing/2018/
+      prefix: /filing/
+      rewrite: ""
       service: {{ include "hmda-platform-ui.fullname" . }}:{{ .Values.service.port }}
 spec:
   clusterIP: None  

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -70,11 +70,11 @@ http {
       try_files $uri =404;
     }
 
-    location /filing/2018 {
+    location /filing/ {
       limit_except GET {
         deny all;
       }
-      try_files '' /filing/2018/index.html;
+      try_files '' /filing/build/index.html;
     }
   }
 

--- a/package.json
+++ b/package.json
@@ -53,5 +53,5 @@
   "devDependencies": {
     "redux-devtools-extension": "2.13.2"
   },
-  "homepage": "/filing/2018"
+  "homepage": "/filing/build/"
 }

--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,7 @@ import { Provider } from 'react-redux'
 import thunkMiddleware from 'redux-thunk'
 import {
   Router,
+  Redirect,
   Route,
   browserHistory,
   IndexRoute,
@@ -65,6 +66,8 @@ history.listen(location => {
 render(
   <Provider store={store}>
     <Router history={history} render={applyRouterMiddleware(useScroll())}>
+      <Redirect from="/" to="/filing/2019/"/>
+      <Redirect from="/filing" to="/filing/2019/"/>
       <Route path={'/filing/:filingPeriod/'} component={AppContainer}>
         <IndexRoute component={HomeContainer} />
         <Route

--- a/src/utils/keycloak.js
+++ b/src/utils/keycloak.js
@@ -42,10 +42,10 @@ const refresh = () => {
 
 const register = () => {
   if (!keycloak) return error('keycloak needs to be set on app initialization')
-
-  getStore().dispatch(isRedirecting(true))
+  const store = getStore()
+  store.dispatch(isRedirecting(true))
   keycloak.login({
-    redirectUri: location.origin + '/filing/2018/institutions',
+    redirectUri: `${location.origin}/filing/${store.getState().app.filingPeriod}/institutions`,
     action: 'register'
   })
 }


### PR DESCRIPTION
This is an alternative implementation of https://github.com/cfpb/hmda-platform-ui/pull/1269:

Things different in this approach:
  - from a kubernetes perspective, it just forwards anything with a /filing prefix to the filing app and ignores the rest of the path
 - the create-react-app homepage and nginx file locations are set to /filing/build. This means that static file requests will come to `.../filing/build/...` (I would have preferred this to be just `/filing` but didn't want to deal with the routing rules for the 2017 platform)
 - the url structure remains the same as in 2018, meaning that people's bookmarks will still be valid without introducing/maintaining any other redirects.
 - keeps the year selector on the homepage, which I think is useful as outlined [here](https://github.com/cfpb/hmda-platform/issues/2864#issuecomment-519676649)