### PR TITLE
Use verified & exists flags to fix routing bugs

### DIFF
--- a/src/institutions/Institution.jsx
+++ b/src/institutions/Institution.jsx
@@ -24,7 +24,7 @@ const Institution = ({ institution, filing, submission, submissions }) => {
           <div className="current-status">
             <InstitutionNameAndId name={institution.name} lei={institution.lei} filingPeriod={filing.period} />
 
-            <SubmissionNav status={status} />
+            <SubmissionNav submission={submission} />
 
             <InstitutionStatus filing={filing} submission={submission} />
 

--- a/src/institutions/Progress.jsx
+++ b/src/institutions/Progress.jsx
@@ -27,7 +27,7 @@ const navMap = {
   },
   'quality edits': {
     isErrored: code => code === QUALITY_EDITS,
-    isCompleted: code => code > QUALITY_EDITS,
+    isCompleted: (code, verified) => verified,
     errorText: 'quality edits',
     completedText: 'quality edits verified'
   },
@@ -45,9 +45,10 @@ const navMap = {
   }
 }
 
-const renderNavItem = (code, name, i) => {
+const renderNavItem = (status, name, i) => {
+  const { code, qualityVerified } = status
   const navItem = navMap[name]
-  const completed = navItem.isCompleted(code)
+  const completed = navItem.isCompleted(code, qualityVerified)
   const errored = navItem.isErrored(code)
 
   let renderedName = name
@@ -84,7 +85,7 @@ const Progress = ({ status = { code: 1 } }) => {
       <nav className="EditsNav" id="editsNav">
         <ul className="nav-primary">
           {Object.keys(navMap).map((name, i) => {
-            return renderNavItem(status.code, name, i)
+            return renderNavItem(status, name, i)
           })}
         </ul>
         <hr className="nav-bg" />

--- a/src/institutions/Progress.jsx
+++ b/src/institutions/Progress.jsx
@@ -4,7 +4,8 @@ import {
   PARSED_WITH_ERRORS,
   PARSED,
   SYNTACTICAL_VALIDITY_EDITS,
-  QUALITY_EDITS,
+  NO_QUALITY_EDITS,
+  NO_MACRO_EDITS,
   MACRO_EDITS,
   VALIDATED,
   SIGNED
@@ -14,43 +15,41 @@ import './Progress.css'
 
 const navMap = {
   upload: {
-    isErrored: code => code === PARSED_WITH_ERRORS,
-    isCompleted: code => code >= PARSED,
+    isErrored: submission => submission.status.code === PARSED_WITH_ERRORS,
+    isCompleted: submission => submission.status.code >= PARSED,
     errorText: 'uploaded with formatting errors',
     completedText: 'uploaded'
   },
   'syntactical & validity edits': {
-    isErrored: code => code === SYNTACTICAL_VALIDITY_EDITS,
-    isCompleted: code => code > SYNTACTICAL_VALIDITY_EDITS,
+    isErrored: submission => submission.status.code === SYNTACTICAL_VALIDITY_EDITS,
+    isCompleted: submission => submission.status.code > SYNTACTICAL_VALIDITY_EDITS,
     errorText: 'syntactical & validity edits',
     completedText: 'no syntactical & validity edits'
   },
   'quality edits': {
-    isErrored: code => code === QUALITY_EDITS,
-    isCompleted: (code, verified) => verified,
-    errorText: 'quality edits',
+    isErrored: submission => submission.qualityExists && !submission.qualityVerified,
+    isCompleted: submission => submission.status.code >= NO_QUALITY_EDITS && (!submission.qualityExists || submission.qualityVerified),
+    errorText: 'quality edits'  ,
     completedText: 'quality edits verified'
   },
   'macro quality edits': {
-    isErrored: code => code === MACRO_EDITS,
-    isCompleted: code => code > MACRO_EDITS,
+    isErrored: submission => submission.macroExists && !submission.macroVerified,
+    isCompleted: submission => (submission.status.code > MACRO_EDITS || submission.status.code === NO_MACRO_EDITS) && (!submission.macroExists || submission.macroVerified),
     errorText: 'macro quality edits',
     completedText: 'macro quality edits verified'
   },
   submission: {
-    isReachable: code => code >= VALIDATED,
+    isReachable: submission => submission.status.code >= VALIDATED || submission.status.code === NO_MACRO_EDITS ,
     isErrored: () => false,
-    isCompleted: code => code === SIGNED,
+    isCompleted: submission => submission.status.code === SIGNED,
     completedText: 'submitted'
   }
 }
 
-const renderNavItem = (status, name, i) => {
-  const { code, qualityVerified } = status
+const renderNavItem = (submission, name, i) => {
   const navItem = navMap[name]
-  const completed = navItem.isCompleted(code, qualityVerified)
-  const errored = navItem.isErrored(code)
-
+  const completed = navItem.isCompleted(submission)
+  const errored = navItem.isErrored(submission)
   let renderedName = name
   let navClass = ''
   if (errored) {
@@ -61,7 +60,7 @@ const renderNavItem = (status, name, i) => {
     navClass = 'complete'
   }
 
-  if (name === 'submission' && navItem.isReachable(code) && !completed) {
+  if (name === 'submission' && navItem.isReachable(submission) && !completed) {
     // using error class is misleading but the styling is what we need
     navClass = 'error'
   }
@@ -79,13 +78,13 @@ const renderNavItem = (status, name, i) => {
   )
 }
 
-const Progress = ({ status = { code: 1 } }) => {
+const Progress = ({submission = { status: { code: 1 } }}) => {
   return (
     <section className="Progress">
       <nav className="EditsNav" id="editsNav">
         <ul className="nav-primary">
           {Object.keys(navMap).map((name, i) => {
-            return renderNavItem(status, name, i)
+            return renderNavItem(submission, name, i)
           })}
         </ul>
         <hr className="nav-bg" />

--- a/src/institutions/Status.jsx
+++ b/src/institutions/Status.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import CSVDownload from '../common/CSVContainer.jsx'
-import { CREATED, SIGNED, VALIDATING } from '../constants/statusCodes.js'
+import { CREATED, NO_QUALITY_EDITS, NO_MACRO_EDITS, SIGNED, VALIDATING } from '../constants/statusCodes.js'
 
 import './Status.css'
 
@@ -14,13 +14,21 @@ const defaultSubmission = {
   }
 }
 
+const qualityMessage = 'Your data has quality edits that need to be reviewed.'
+const submitMessage = 'Your data is ready for submission.'
+const submitDesc = 'Your financial institution has certified that the data is correct, but it has not been submitted yet.'
+
+
 const InstitutionStatus = props => {
   const submission = props.submission || defaultSubmission
   const { code, message, description } = submission.status
+  const qualityOverride = code > NO_QUALITY_EDITS && (submission.qualityExists && !submission.qualityVerified)
+  const submitOverride = code === NO_MACRO_EDITS
+
   return (
     <section className="status">
-      <h4>{message}</h4>
-      <p>{description}</p>
+      <h4>{qualityOverride ? qualityMessage : submitOverride ? submitMessage : message}</h4>
+      <p>{submitOverride ? submitDesc : description}</p>
       {props.filing.status.code === 3 && code !== SIGNED ? (
         <p className="text-small">
           You have previously submitted a HMDA file and are in the process of

--- a/src/institutions/ViewButton.jsx
+++ b/src/institutions/ViewButton.jsx
@@ -9,6 +9,7 @@ import {
   PARSED_WITH_ERRORS,
   NO_SYNTACTICAL_VALIDITY_EDITS,
   VALIDATING,
+  NO_MACRO_EDITS,
   VALIDATED
 } from '../constants/statusCodes.js'
 
@@ -27,9 +28,9 @@ const InstitutionViewButton = ({ status, institution, filingPeriod }) => {
     text = 'Review formatting errors'
   } else if (code < NO_SYNTACTICAL_VALIDITY_EDITS) {
     text = 'View progress'
-  } else if (code > VALIDATING && code < VALIDATED) {
+  } else if (code > VALIDATING && code < VALIDATED && code !== NO_MACRO_EDITS) {
     text = 'Review edits'
-  } else if (code === VALIDATED) {
+  } else if (code === VALIDATED || code === NO_MACRO_EDITS) {
     text = 'Review summary'
   } else {
     text = 'View completed filing'

--- a/src/reducers/submission.js
+++ b/src/reducers/submission.js
@@ -3,6 +3,8 @@ import {
   SELECT_FILE,
   REQUEST_SUBMISSION,
   UPDATE_STATUS,
+  VERIFY_QUALITY,
+  VERIFY_MACRO,
   REFRESH_STATE
 } from '../constants'
 import { UNINITIALIZED } from '../constants/statusCodes.js'
@@ -14,6 +16,10 @@ const defaultSubmission = {
     code: UNINITIALIZED,
     message: ''
   },
+  qualityExists: false,
+  qualityVerified: false,
+  macroExists: false,
+  macroVerified: false,
   isFetching: false
 }
 
@@ -31,7 +37,11 @@ export default (state = defaultSubmission, action) => {
           isFetching: false,
           filename: action.fileName,
           id: action.id,
-          status: action.status
+          status: action.status,
+          qualityExists: action.qualityExists || false,
+          qualityVerified: action.qualityVerified || false,
+          macroExists: action.macroExists || false,
+          macroVerified: action.macroVerified || false
         }
       return state
     case SELECT_FILE:
@@ -50,6 +60,17 @@ export default (state = defaultSubmission, action) => {
         ...state,
         status: action.status
       }
+    case VERIFY_QUALITY:
+      return {
+        ...state,
+        qualityVerified: action.checked
+      }
+    case VERIFY_MACRO:
+      return {
+        ...state,
+        macroVerified: action.checked
+      }
+
     case REFRESH_STATE:
       return defaultSubmission
     default:

--- a/src/submission/Nav.jsx
+++ b/src/submission/Nav.jsx
@@ -7,6 +7,7 @@ import {
   NO_SYNTACTICAL_VALIDITY_EDITS,
   SYNTACTICAL_VALIDITY_EDITS,
   NO_QUALITY_EDITS,
+  NO_MACRO_EDITS,
   MACRO_EDITS,
   VALIDATED,
   SIGNED
@@ -51,9 +52,9 @@ export default class EditsNav extends Component {
           this.props.editsFetched && this.navMap['syntactical & validity edits'].isCompleted(),
         isErrored: () => this.props.qualityExists && !this.props.qualityVerified,
         isCompleted: () =>
-          (this.navMap['quality edits'].isReachable() &&
-            this.props.qualityVerified) ||
-          this.props.code === NO_QUALITY_EDITS,
+          this.navMap['quality edits'].isReachable() &&
+          this.props.code >= NO_QUALITY_EDITS &&
+          (this.props.qualityVerified || !this.props.qualityExists),
         errorClass: 'warning-question',
         errorText: 'quality edits found',
         completedText: 'quality edits verified',
@@ -61,17 +62,18 @@ export default class EditsNav extends Component {
       },
       'macro quality edits': {
         isReachable: () => this.props.editsFetched && this.navMap['quality edits'].isCompleted(),
-        isErrored: () => this.props.code === MACRO_EDITS,
+        isErrored: () => this.props.macroExists && !this.props.macroVerified,
         isCompleted: () =>
           this.navMap['macro quality edits'].isReachable() &&
-            this.props.code > MACRO_EDITS,
+          (this.props.code > MACRO_EDITS || this.props.code === NO_MACRO_EDITS) &&
+          (!this.props.macroExists || this.props.macroVerified),
         errorClass: 'warning-question',
         errorText: 'macro quality edits found',
         completedText: 'macro quality edits verified',
         link: 'macro'
       },
       submission: {
-        isReachable: () => this.props.code >= VALIDATED,
+        isReachable: () => this.props.code >= VALIDATED || this.props.code === NO_MACRO_EDITS,
         isErrored: () => false,
         isCompleted: () => this.props.code === SIGNED,
         completedText: 'submitted',
@@ -183,5 +185,7 @@ EditsNav.propTypes = {
   code: PropTypes.number.isRequired,
   editsFetched: PropTypes.bool.isRequired,
   qualityExists: PropTypes.bool.isRequired,
-  qualityVerified: PropTypes.bool.isRequired
+  qualityVerified: PropTypes.bool.isRequired,
+  macroExists: PropTypes.bool.isRequired,
+  macroVerified: PropTypes.bool.isRequired
 }

--- a/src/submission/progressHOC.jsx
+++ b/src/submission/progressHOC.jsx
@@ -14,10 +14,9 @@ function mapStateToProps(state) {
     .slice(0, -1)
     .join('/')
 
-  const { code } = state.app.submission.status
+  const { code, qualityVerified } = state.app.submission.status
   const editsFetched = state.app.edits.fetched
   const qualityExists = !!state.app.edits.types.quality.edits.length
-  const qualityVerified = state.app.edits.types.quality.verified
   const validationComplete =
     code === SYNTACTICAL_VALIDITY_EDITS || code >= NO_MACRO_EDITS
 

--- a/src/submission/progressHOC.jsx
+++ b/src/submission/progressHOC.jsx
@@ -14,9 +14,9 @@ function mapStateToProps(state) {
     .slice(0, -1)
     .join('/')
 
-  const { code, qualityVerified } = state.app.submission.status
+  const { status, qualityVerified, qualityExists, macroVerified, macroExists } = state.app.submission
+  const { code } = status
   const editsFetched = state.app.edits.fetched
-  const qualityExists = !!state.app.edits.types.quality.edits.length
   const validationComplete =
     code === SYNTACTICAL_VALIDITY_EDITS || code >= NO_MACRO_EDITS
 
@@ -27,7 +27,9 @@ function mapStateToProps(state) {
     editsFetched,
     validationComplete,
     qualityExists,
-    qualityVerified
+    qualityVerified,
+    macroExists,
+    macroVerified
   }
 }
 

--- a/src/submission/router.jsx
+++ b/src/submission/router.jsx
@@ -80,14 +80,13 @@ export class SubmissionRouter extends Component {
   }
 
   getLatestPage() {
-    const status = this.props.submission.status
-    const code = status.code
-    const { qualityVerified } = status
+    const {status, qualityExists, qualityVerified } = this.props.submission
+    const { code } = status
 
     if (code <= VALIDATING || code === NO_QUALITY_EDITS) return 'upload'
-    if (code >= VALIDATED) return 'submission'
+    if (code >= VALIDATED || code === NO_MACRO_EDITS) return 'submission'
     if (code === SYNTACTICAL_VALIDITY_EDITS) return 'syntacticalvalidity'
-    if (code >= QUALITY_EDITS && !qualityVerified) return 'quality'
+    if (code >= QUALITY_EDITS && qualityExists && !qualityVerified) return 'quality'
     return 'macro'
   }
 

--- a/src/submission/router.jsx
+++ b/src/submission/router.jsx
@@ -82,7 +82,7 @@ export class SubmissionRouter extends Component {
   getLatestPage() {
     const status = this.props.submission.status
     const code = status.code
-    const qualityVerified = this.props.types.quality.verified
+    const { qualityVerified } = status
 
     if (code <= VALIDATING || code === NO_QUALITY_EDITS) return 'upload'
     if (code >= VALIDATED) return 'submission'

--- a/src/submission/signature/index.jsx
+++ b/src/submission/signature/index.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import ErrorWarning from '../../common/ErrorWarning.jsx'
-import { VALIDATED, SIGNED } from '../../constants/statusCodes.js'
+import { VALIDATED, NO_MACRO_EDITS, SIGNED } from '../../constants/statusCodes.js'
 
 import './Signature.css'
 
@@ -17,7 +17,7 @@ const showWarning = props => {
 
 const Signature = props => {
   let isButtonDisabled =
-    props.status.code === VALIDATED && props.checked ? false : true
+    (props.status.code === VALIDATED || props.status.code === NO_MACRO_EDITS) && props.checked ? false : true
 
   let isCheckBoxDisabled = props.status.code === SIGNED ? true : false
 


### PR DESCRIPTION
Closed #1293

Somewhat involved change since lots of pieces of the front-end assumed the code was the one source of truth of submission status, which is no longer the case.

Also, this patches up some strange backend behavior when there are quality edits but no macro edits that required a fair amount of special casing peppered throughout the code.