### PR TITLE
 updating signed submission page to support multi year logic

### DIFF
--- a/src/submission/container.jsx
+++ b/src/submission/container.jsx
@@ -50,7 +50,7 @@ const renderByCode = (code, page, lei, filingPeriod) => {
         toRender.push(<ReadyToSign />)
       }
       toRender.push(<ReceiptContainer />)
-      toRender.push(<IRSReport lei={lei} />)
+      toRender.push(<IRSReport lei={lei} filingPeriod={filingPeriod} />)
       toRender.push(<Summary />)
 
       // and just before the signature

--- a/src/submission/irs/index.jsx
+++ b/src/submission/irs/index.jsx
@@ -30,7 +30,7 @@ const filingPeriod=props.filingPeriod
         </p>
         <p className="text-small">
           Loan amounts in the IRS are binned and disclosed in accordance
-          with the {filingPeriod} HMDA data publication policy guidance. An overview
+          with the 2018 HMDA data publication policy guidance. An overview
           of the policy guidance can be found in this <a href="https://www.consumerfinance.gov/documents/7052/HMDA_Data_Disclosure_Policy_Guidance.Executive_Summary.FINAL.12212018.pdf">executive summary</a>.
         </p>
       </header>

--- a/src/submission/irs/index.jsx
+++ b/src/submission/irs/index.jsx
@@ -4,12 +4,14 @@ import PropTypes from 'prop-types'
 import './IRSReport.css'
 
 const IRSReport = props => {
+
+const filingPeriod=props.filingPeriod
   return (
     <section className="IRSReport">
       <header>
         <h2>Institution Register Summary</h2>
         <p className="font-lead">
-          During the 2018 filing period, the IRS will be made available in the
+          During the {filingPeriod} filing period, the IRS will be made available in the
           HMDA Platform after signing and submitting your HMDA data. The IRS
           will not be available immediately. Please check back shortly after
           submitting your data to access your IRS.
@@ -17,7 +19,7 @@ const IRSReport = props => {
         <p>
           When ready, the IRS will be available for{' '}
           <a
-            href={`https://s3.amazonaws.com/cfpb-hmda-public/prod/reports/disclosure/2018/${
+            href={`https://s3.amazonaws.com/cfpb-hmda-public/prod/reports/disclosure/${filingPeriod}/${
               props.lei
             }/nationwide/IRS.csv`}
             download={true}
@@ -28,7 +30,7 @@ const IRSReport = props => {
         </p>
         <p className="text-small">
           Loan amounts in the IRS are binned and disclosed in accordance
-          with the 2018 HMDA data publication policy guidance. An overview
+          with the {filingPeriod} HMDA data publication policy guidance. An overview
           of the policy guidance can be found in this <a href="https://www.consumerfinance.gov/documents/7052/HMDA_Data_Disclosure_Policy_Guidance.Executive_Summary.FINAL.12212018.pdf">executive summary</a>.
         </p>
       </header>


### PR DESCRIPTION
closes #1301 


 The guidance document does not  change annually so that portion of the page will still reflect 2018